### PR TITLE
Some async method in Client implementation didn't need to be async at all

### DIFF
--- a/examples/chat-client/src/main.rs
+++ b/examples/chat-client/src/main.rs
@@ -39,6 +39,6 @@ async fn main() {
     for line in lines {
         let line = line.unwrap();
         tracing::info!("sending {line}");
-        handle.text(line).await;
+        handle.text(line);
     }
 }

--- a/examples/simple-client/src/main.rs
+++ b/examples/simple-client/src/main.rs
@@ -42,6 +42,6 @@ async fn main() {
     for line in lines {
         let line = line.unwrap();
         tracing::info!("sending {line}");
-        handle.text(line).await;
+        handle.text(line);
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -90,15 +90,15 @@ impl<E: ClientExt> From<Client<E>> for mpsc::UnboundedSender<E::Params> {
 }
 
 impl<E: ClientExt> Client<E> {
-    pub async fn text(&self, text: String) {
+    pub fn text(&self, text: String) {
         self.socket.send(Message::Text(text)).unwrap();
     }
 
-    pub async fn binary(&self, bytes: Vec<u8>) {
+    pub fn binary(&self, bytes: Vec<u8>) {
         self.socket.send(Message::Binary(bytes)).unwrap();
     }
 
-    pub async fn call(&self, message: E::Params) {
+    pub fn call(&self, message: E::Params) {
         self.calls.send(message).unwrap();
     }
 

--- a/tests/chat.rs
+++ b/tests/chat.rs
@@ -243,7 +243,7 @@ impl ezsockets::ClientExt for ChatClient {
 
     async fn call(&mut self, params: Self::Params) -> Result<(), ezsockets::Error> {
         match params {
-            ChatClientMessage::Send(message) => self.handle.text(message).await,
+            ChatClientMessage::Send(message) => self.handle.text(message),
             ChatClientMessage::Subscribe(respond_to) => {
                 respond_to.send(self.messages.subscribe()).unwrap()
             }
@@ -256,32 +256,26 @@ pub async fn test(alice: Client<ChatClient>, bob: Client<ChatClient>) {
     let mut bob_messages = bob.call_with(ChatClientMessage::Subscribe).await;
     let mut alice_messages = alice.call_with(ChatClientMessage::Subscribe).await;
     alice
-        .call(ChatClientMessage::Send("Hi Bob!".to_string()))
-        .await;
+        .call(ChatClientMessage::Send("Hi Bob!".to_string()));
     alice
-        .call(ChatClientMessage::Send("Cya Bob!".to_string()))
-        .await;
+        .call(ChatClientMessage::Send("Cya Bob!".to_string()));
     assert_eq!(bob_messages.recv().await.unwrap(), "Hi Bob!".to_string());
     assert_eq!(bob_messages.recv().await.unwrap(), "Cya Bob!".to_string());
     alice
-        .call(ChatClientMessage::Send(format!("/join abc")))
-        .await;
+        .call(ChatClientMessage::Send(format!("/join abc")));
 
     alice
-        .call(ChatClientMessage::Send("Is there anyone?".to_string())) // no
-        .await;
+        .call(ChatClientMessage::Send("Is there anyone?".to_string())); // no
 
     tokio::time::sleep(Duration::from_millis(100)).await; // sorry for this hack, but i can't find a better solution right now
-    bob.call(ChatClientMessage::Send(format!("/join abc")))
-        .await;
+    bob.call(ChatClientMessage::Send(format!("/join abc")));
 
     assert_eq!(
         alice_messages.recv().await.unwrap(),
         "User with ID: 1 just joined abc room".to_string()
     );
     alice
-        .call(ChatClientMessage::Send("Hi in the new room".to_string()))
-        .await;
+        .call(ChatClientMessage::Send("Hi in the new room".to_string()));
     assert_eq!(
         bob_messages.recv().await.unwrap(),
         "Hi in the new room".to_string()


### PR DESCRIPTION
The `binary`, `text`, and `call` methods are just calling a synchronous function and returns immediately, so there's no apparent reason to make them async function as it is. (unless you have plans for the future and want your API to be like this already to match your future plans)