### PR TITLE
feat: client connection handlers

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -71,11 +71,11 @@ pub trait ClientExt: Send {
     async fn text(&mut self, text: String) -> Result<(), Error>;
     async fn binary(&mut self, bytes: Vec<u8>) -> Result<(), Error>;
     async fn call(&mut self, params: Self::Params) -> Result<(), Error>;
-
+    
     /// Called when the connection is closed.
     /// 
     /// For reconnections, use `ClientConfig::reconnect_interval`.
-    async fn close(&mut self) -> Result<(), Error> {
+    async fn closed(&mut self) -> Result<(), Error> {
         Ok(())
     }
 }
@@ -189,7 +189,7 @@ impl<E: ClientExt> ClientActor<E> {
                                 Message::Text(text) => self.client.text(text).await?,
                                 Message::Binary(bytes) => self.client.binary(bytes).await?,
                                 Message::Close(_frame) => {
-                                    self.client.close().await?;
+                                    self.client.closed().await?;
                                     self.reconnect().await;
                                 }
                             };
@@ -198,7 +198,7 @@ impl<E: ClientExt> ClientActor<E> {
                             tracing::error!("connection error: {error}");
                         }
                         None => {
-                            self.client.close().await?;
+                            self.client.closed().await?;
                             self.reconnect().await;
                         }
                     };

--- a/src/client.rs
+++ b/src/client.rs
@@ -11,7 +11,7 @@ use tokio::time::Instant;
 use tokio_tungstenite::tungstenite;
 use url::Url;
 
-const DEFAULT_RECONNECT_INTERVAL: Duration = Duration::new(5, 0);
+pub const DEFAULT_RECONNECT_INTERVAL: Duration = Duration::new(5, 0);
 
 #[derive(Debug)]
 pub struct ClientConfig {

--- a/src/client.rs
+++ b/src/client.rs
@@ -37,6 +37,11 @@ impl ClientConfig {
         );
         self
     }
+    
+    pub fn reconnect_interval(mut self, reconnect_interval: Duration) -> Self {
+        self.reconnect_interval = Some(reconnect_interval);
+        self
+    }
 
     fn connect_http_request(&self) -> http::Request<()> {
         let mut http_request = http::Request::builder()


### PR DESCRIPTION
functions to be added on `ClientExt`:
- `closed()` - called when the connection is closed
- `connected()` - called when the client has successfully connected, or reconnected