### PR TITLE
refactor: rename methods and types for better distinction

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,220 +6,32 @@ Creating a WebSocket server or a client in Rust can be troublesome. This crate f
 - Traits to allow declarative and event-based programming.
 - Automatic reconnection of WebSocket Client.
 
+## Documentation
+
 View the full documentation at [docs.rs/ezsockets](http://docs.rs/ezsockets)
+
+## Examples
+- [`simple-client`](/examples/simple-client) - a simplest WebSocket client which uses stdin as input.
+- [`echo-server`](/examples/echo-server) - server that echoes back every message it receives.
+- [`counter-server`](/examples/counter-server) - server that increments global value every second and shares it with client
+- [`chat-client`](/examples/chat-client) - chat client for `chat-server` and `chat-server-axum` examples
+- [`chat-server`](/examples/chat-server) - chat server with support of rooms
+- [`chat-server-axum`](/examples/chat-server-axum) - same as above, but using `axum` as a back-end
+
 
 ## Client
 
-The code below represents a simple client that redirects stdin to the WebSocket server.
+[`tokio-tungstenite`](https://github.com/snapview/tokio-tungstenite) is being used under the hood.
 
-```rust
-use async_trait::async_trait;
-use ezsockets::ClientConfig;
-use std::io::BufRead;
-use url::Url;
-
-struct Client {}
-
-#[async_trait]
-impl ezsockets::ClientExt for Client {
-    type Params = ();
-
-    async fn text(&mut self, text: String) -> Result<(), ezsockets::Error> {
-        tracing::info!("received message: {text}");
-        Ok(())
-    }
-
-    async fn binary(&mut self, bytes: Vec<u8>) -> Result<(), ezsockets::Error> {
-        tracing::info!("received bytes: {bytes:?}");
-        Ok(())
-    }
-
-    async fn call(&mut self, params: Self::Params) -> Result<(), ezsockets::Error> {
-        let () = params;
-        Ok(())
-    }
-}
-
-#[tokio::main]
-async fn main() {
-    tracing_subscriber::fmt::init();
-    let config = ClientConfig::new("ws://localhost:8080/websocket");
-    let (handle, future) = ezsockets::connect(|_client| Client { }, config).await;
-    tokio::spawn(async move {
-        future.await.unwrap();
-    });
-    let stdin = std::io::stdin();
-    let lines = stdin.lock().lines();
-    for line in lines {
-        let line = line.unwrap();
-        tracing::info!("sending {line}");
-        handle.text(line);
-    }
-}
-
-```
-
+See [examples/simple-client](/examples/simple-client) for a simple usage
+and [docs.rs/ezsockets/server](https://docs.rs/ezsockets/latest/ezsockets/client/index.html) for documentation.
 
 ## Server
 
-To create a simple echo server, we need to define a `Session` struct.
-The code below represents a simple echo server.
+WebSocket server can use one of supported back-ends:
+- [`tokio-tungstenite`](https://github.com/snapview/tokio-tungstenite) - the simplest way to get started.
+- [`axum`](https://github.com/tokio-rs/axum) - ergonomic and modular web framework built with Tokio, Tower, and Hyper
+- [`actix-web`](https://github.com/actix/actix-web) - Work in progress at [#22](https://github.com/gbaranski/ezsockets/issues/22)
 
-```rust
-use async_trait::async_trait;
-use ezsockets::Session;
-
-type SessionID = u16;
-
-struct EchoSession {
-    handle: Session,
-    id: SessionID,
-}
-
-#[async_trait]
-impl ezsockets::SessionExt for EchoSession {
-    type ID = SessionID;
-    type Args = ();
-    type Params = ();
-
-    fn id(&self) -> &Self::ID {
-        &self.id
-    }
-
-    async fn text(&mut self, text: String) -> Result<(), ezsockets::Error> {
-        self.handle.text(text); // Send response to the client
-        Ok(())
-    }
-
-    async fn binary(&mut self, _bytes: Vec<u8>) -> Result<(), ezsockets::Error> {
-        unimplemented!()
-    }
-
-    async fn call(&mut self, params: Self::Params) -> Result<(), ezsockets::Error> {
-        let () = params;
-        Ok(())
-    }
-}
-```
-
-Then, we need to define a `Server` struct
-
-
-```rust
-use async_trait::async_trait;
-use ezsockets::Server;
-use ezsockets::Session;
-use ezsockets::Socket;
-use std::net::SocketAddr;
-
-struct EchoServer {}
-
-#[async_trait]
-impl ezsockets::ServerExt for EchoServer {
-    type Session = EchoSession;
-    type Params = ();
-
-    async fn accept(
-        &mut self,
-        socket: Socket,
-        address: SocketAddr,
-        _args: (),
-    ) -> Result<Session, ezsockets::Error> {
-        let id = address.port();
-        let session = Session::create(|handle| EchoSession { id, handle }, id, socket);
-        Ok(session)
-    }
-
-    async fn disconnected(
-        &mut self,
-        _id: <Self::Session as ezsockets::SessionExt>::ID,
-    ) -> Result<(), ezsockets::Error> {
-        Ok(())
-    }
-
-    async fn call(&mut self, params: Self::Params) -> Result<(), ezsockets::Error> {
-        let () = params;
-        Ok(())
-    }
-}
-```
-
-That's all! Now we can start the server. Take a look at the available [Server back-ends](#server-back-ends). For a simple usage, I'd recommend [tokio-tungstenite](#tokio-tungstenite).
-
-## Server back-ends
-
-- [x] [`tokio-tungstenite`](#tokio-tungstenite), a neat Tokio based WebSocket implementation. However, it does not provide fancy features like routing or authentication.
-- [x] [`axum`](#axum), an ergonomic and modular web framework built with Tokio, Tower, and Hyper.
-- [ ] [`actix-web`](#actix-web) a powerful, pragmatic, and extremely fast web framework for Rust.
-
-### [`tokio-tungstenite`](https://github.com/snapview/tokio-tungstenite)
-
-Enable using
-```toml
-ezsockets = { version = "0.4", features = ["tungstenite"] }
-```
-
-```rust
-struct EchoServer {}
-
-#[async_trait]
-impl ezsockets::ServerExt for EchoServer {
-    // ...
-}
-
-#[tokio::main]
-async fn main() {
-    let (server, _) = ezsockets::Server::create(|_| EchoServer {});
-    ezsockets::tungstenite::run(server, "127.0.0.1:8080", |_socket| async move { Ok(()) })
-        .await
-        .unwrap();
-}
-```
-
-### [`axum`](https://github.com/tokio-rs/axum)
-
-Enable using
-```toml
-ezsockets = { version = "0.4", features = ["axum"] }
-```
-
-```rust
-struct EchoServer {}
-
-#[async_trait]
-impl ezsockets::ServerExt for EchoServer {
-    // ...
-}
-
-#[tokio::main]
-async fn main() {
-    let (server, _) = ezsockets::Server::create(|_| EchoServer {});
-    let app = axum::Router::new()
-        .route("/websocket", get(websocket_handler))
-        .layer(Extension(server.clone()));
-
-    let address = std::net::SocketAddr::from(([127, 0, 0, 1], 8080));
-
-    tokio::spawn(async move {
-        tracing::debug!("listening on {}", address);
-        axum::Server::bind(&address)
-            .serve(app.into_make_service_with_connect_info::<SocketAddr>())
-            .await
-            .unwrap();
-    });
-
-}
-
-async fn websocket_handler(
-    Extension(server): Extension<ezsockets::Server>,
-    ezsocket: Upgrade,
-) -> impl IntoResponse {
-    ezsocket.on_upgrade(|socket, address| async move {
-        server.accept(socket, address, ()).await;
-    })
-}
-```
-
-### [`actix-web`](https://github.com/actix/actix-web)
-
-Work in progress!
+See [examples/echo-server](/examples/echo-server) for a simple usage
+and [docs.rs/ezsockets/server](https://docs.rs/ezsockets/latest/ezsockets/server/index.html) for documentation.

--- a/benches/ezsockets_server.rs
+++ b/benches/ezsockets_server.rs
@@ -11,9 +11,9 @@ struct EchoServer {}
 #[async_trait]
 impl ezsockets::ServerExt for EchoServer {
     type Session = EchoSession;
-    type Params = ();
+    type Call = ();
 
-    async fn accept(
+    async fn on_connect(
         &mut self,
         socket: ezsockets::Socket,
         address: SocketAddr,
@@ -24,14 +24,14 @@ impl ezsockets::ServerExt for EchoServer {
         Ok(session)
     }
 
-    async fn disconnected(
+    async fn on_disconnect(
         &mut self,
         _id: <Self::Session as ezsockets::SessionExt>::ID,
     ) -> Result<(), ezsockets::Error> {
         Ok(())
     }
 
-    async fn call(&mut self, params: Self::Params) -> Result<(), ezsockets::Error> {
+    async fn on_call(&mut self, params: Self::Call) -> Result<(), ezsockets::Error> {
         let () = params;
         Ok(())
     }
@@ -46,22 +46,22 @@ struct EchoSession {
 impl ezsockets::SessionExt for EchoSession {
     type ID = SessionID;
     type Args = ();
-    type Params = ();
+    type Call = ();
 
     fn id(&self) -> &Self::ID {
         &self.id
     }
 
-    async fn text(&mut self, text: String) -> Result<(), ezsockets::Error> {
+    async fn on_text(&mut self, text: String) -> Result<(), ezsockets::Error> {
         self.handle.text(text);
         Ok(())
     }
 
-    async fn binary(&mut self, _bytes: Vec<u8>) -> Result<(), ezsockets::Error> {
+    async fn on_binary(&mut self, _bytes: Vec<u8>) -> Result<(), ezsockets::Error> {
         unimplemented!()
     }
 
-    async fn call(&mut self, params: Self::Params) -> Result<(), ezsockets::Error> {
+    async fn on_call(&mut self, params: Self::Call) -> Result<(), ezsockets::Error> {
         let () = params;
         Ok(())
     }

--- a/benches/ezsockets_server.rs
+++ b/benches/ezsockets_server.rs
@@ -31,8 +31,8 @@ impl ezsockets::ServerExt for EchoServer {
         Ok(())
     }
 
-    async fn on_call(&mut self, params: Self::Call) -> Result<(), ezsockets::Error> {
-        let () = params;
+    async fn on_call(&mut self, call: Self::Call) -> Result<(), ezsockets::Error> {
+        let () = call;
         Ok(())
     }
 }
@@ -61,8 +61,8 @@ impl ezsockets::SessionExt for EchoSession {
         unimplemented!()
     }
 
-    async fn on_call(&mut self, params: Self::Call) -> Result<(), ezsockets::Error> {
-        let () = params;
+    async fn on_call(&mut self, call: Self::Call) -> Result<(), ezsockets::Error> {
+        let () = call;
         Ok(())
     }
 }

--- a/examples/chat-client/src/main.rs
+++ b/examples/chat-client/src/main.rs
@@ -6,19 +6,19 @@ struct Client {}
 
 #[async_trait]
 impl ezsockets::ClientExt for Client {
-    type Params = ();
+    type Call = ();
 
-    async fn text(&mut self, text: String) -> Result<(), ezsockets::Error> {
+    async fn on_text(&mut self, text: String) -> Result<(), ezsockets::Error> {
         tracing::info!("received message: {text}");
         Ok(())
     }
 
-    async fn binary(&mut self, bytes: Vec<u8>) -> Result<(), ezsockets::Error> {
+    async fn on_binary(&mut self, bytes: Vec<u8>) -> Result<(), ezsockets::Error> {
         tracing::info!("received bytes: {bytes:?}");
         Ok(())
     }
 
-    async fn call(&mut self, params: Self::Params) -> Result<(), ezsockets::Error> {
+    async fn on_call(&mut self, params: Self::Call) -> Result<(), ezsockets::Error> {
         let () = params;
         Ok(())
     }

--- a/examples/chat-client/src/main.rs
+++ b/examples/chat-client/src/main.rs
@@ -18,8 +18,8 @@ impl ezsockets::ClientExt for Client {
         Ok(())
     }
 
-    async fn on_call(&mut self, params: Self::Call) -> Result<(), ezsockets::Error> {
-        let () = params;
+    async fn on_call(&mut self, call: Self::Call) -> Result<(), ezsockets::Error> {
+        let () = call;
         Ok(())
     }
 }

--- a/examples/chat-server-axum/src/main.rs
+++ b/examples/chat-server-axum/src/main.rs
@@ -27,9 +27,9 @@ struct ChatServer {
 #[async_trait]
 impl ezsockets::ServerExt for ChatServer {
     type Session = ChatSession;
-    type Params = ChatMessage;
+    type Call = ChatMessage;
 
-    async fn accept(
+    async fn on_connect(
         &mut self,
         socket: Socket,
         _address: SocketAddr,
@@ -48,7 +48,7 @@ impl ezsockets::ServerExt for ChatServer {
         Ok(session)
     }
 
-    async fn disconnected(
+    async fn on_disconnect(
         &mut self,
         id: <Self::Session as ezsockets::SessionExt>::ID,
     ) -> Result<(), Error> {
@@ -56,7 +56,7 @@ impl ezsockets::ServerExt for ChatServer {
         Ok(())
     }
 
-    async fn call(&mut self, params: Self::Params) -> Result<(), Error> {
+    async fn on_call(&mut self, params: Self::Call) -> Result<(), Error> {
         match params {
             ChatMessage::Send { text, from } => {
                 let sessions = self.sessions.iter().filter(|(id, _)| from != **id);
@@ -80,12 +80,12 @@ struct ChatSession {
 impl ezsockets::SessionExt for ChatSession {
     type ID = SessionID;
     type Args = ();
-    type Params = ();
+    type Call = ();
 
     fn id(&self) -> &Self::ID {
         &self.id
     }
-    async fn text(&mut self, text: String) -> Result<(), Error> {
+    async fn on_text(&mut self, text: String) -> Result<(), Error> {
         tracing::info!("received: {text}");
         self.server.call(ChatMessage::Send {
             from: self.id,
@@ -94,11 +94,11 @@ impl ezsockets::SessionExt for ChatSession {
         Ok(())
     }
 
-    async fn binary(&mut self, _bytes: Vec<u8>) -> Result<(), Error> {
+    async fn on_binary(&mut self, _bytes: Vec<u8>) -> Result<(), Error> {
         unimplemented!()
     }
 
-    async fn call(&mut self, params: Self::Params) -> Result<(), Error> {
+    async fn on_call(&mut self, params: Self::Call) -> Result<(), Error> {
         let () = params;
         Ok(())
     }

--- a/examples/chat-server-axum/src/main.rs
+++ b/examples/chat-server-axum/src/main.rs
@@ -56,8 +56,8 @@ impl ezsockets::ServerExt for ChatServer {
         Ok(())
     }
 
-    async fn on_call(&mut self, params: Self::Call) -> Result<(), Error> {
-        match params {
+    async fn on_call(&mut self, call: Self::Call) -> Result<(), Error> {
+        match call {
             ChatMessage::Send { text, from } => {
                 let sessions = self.sessions.iter().filter(|(id, _)| from != **id);
                 let text = format!("from {from}: {text}");
@@ -98,8 +98,8 @@ impl ezsockets::SessionExt for ChatSession {
         unimplemented!()
     }
 
-    async fn on_call(&mut self, params: Self::Call) -> Result<(), Error> {
-        let () = params;
+    async fn on_call(&mut self, call: Self::Call) -> Result<(), Error> {
+        let () = call;
         Ok(())
     }
 }

--- a/examples/chat-server/src/main.rs
+++ b/examples/chat-server/src/main.rs
@@ -31,10 +31,10 @@ struct ChatServer {
 
 #[async_trait]
 impl ezsockets::ServerExt for ChatServer {
-    type Params = Message;
+    type Call = Message;
     type Session = SessionActor;
 
-    async fn accept(
+    async fn on_connect(
         &mut self,
         socket: Socket,
         _address: SocketAddr,
@@ -55,7 +55,7 @@ impl ezsockets::ServerExt for ChatServer {
         Ok(session)
     }
 
-    async fn disconnected(
+    async fn on_disconnect(
         &mut self,
         id: <Self::Session as ezsockets::SessionExt>::ID,
     ) -> Result<(), Error> {
@@ -70,7 +70,7 @@ impl ezsockets::ServerExt for ChatServer {
         Ok(())
     }
 
-    async fn call(&mut self, params: Self::Params) -> Result<(), Error> {
+    async fn on_call(&mut self, params: Self::Call) -> Result<(), Error> {
         match params {
             Message::Send { from, room, text } => {
                 let (ids, sessions): (Vec<SessionID>, Vec<&Session>) = self
@@ -133,13 +133,13 @@ struct SessionActor {
 impl ezsockets::SessionExt for SessionActor {
     type ID = SessionID;
     type Args = ();
-    type Params = ();
+    type Call = ();
 
     fn id(&self) -> &Self::ID {
         &self.id
     }
 
-    async fn text(&mut self, text: String) -> Result<(), Error> {
+    async fn on_text(&mut self, text: String) -> Result<(), Error> {
         tracing::info!("received: {text}");
         if text.starts_with('/') {
             let mut args = text.split_whitespace();
@@ -162,11 +162,11 @@ impl ezsockets::SessionExt for SessionActor {
         Ok(())
     }
 
-    async fn binary(&mut self, _bytes: Vec<u8>) -> Result<(), Error> {
+    async fn on_binary(&mut self, _bytes: Vec<u8>) -> Result<(), Error> {
         unimplemented!()
     }
 
-    async fn call(&mut self, params: Self::Params) -> Result<(), Error> {
+    async fn on_call(&mut self, params: Self::Call) -> Result<(), Error> {
         let () = params;
         Ok(())
     }

--- a/examples/chat-server/src/main.rs
+++ b/examples/chat-server/src/main.rs
@@ -70,8 +70,8 @@ impl ezsockets::ServerExt for ChatServer {
         Ok(())
     }
 
-    async fn on_call(&mut self, params: Self::Call) -> Result<(), Error> {
-        match params {
+    async fn on_call(&mut self, call: Self::Call) -> Result<(), Error> {
+        match call {
             Message::Send { from, room, text } => {
                 let (ids, sessions): (Vec<SessionID>, Vec<&Session>) = self
                     .rooms
@@ -166,8 +166,8 @@ impl ezsockets::SessionExt for SessionActor {
         unimplemented!()
     }
 
-    async fn on_call(&mut self, params: Self::Call) -> Result<(), Error> {
-        let () = params;
+    async fn on_call(&mut self, call: Self::Call) -> Result<(), Error> {
+        let () = call;
         Ok(())
     }
 }

--- a/examples/counter-server/src/main.rs
+++ b/examples/counter-server/src/main.rs
@@ -15,9 +15,9 @@ struct CounterServer {}
 #[async_trait]
 impl ezsockets::ServerExt for CounterServer {
     type Session = CounterSession;
-    type Params = ();
+    type Call = ();
 
-    async fn accept(
+    async fn on_connect(
         &mut self,
         socket: Socket,
         address: SocketAddr,
@@ -49,14 +49,14 @@ impl ezsockets::ServerExt for CounterServer {
         Ok(session)
     }
 
-    async fn disconnected(
+    async fn on_disconnect(
         &mut self,
         _id: <Self::Session as ezsockets::SessionExt>::ID,
     ) -> Result<(), Error> {
         Ok(())
     }
 
-    async fn call(&mut self, params: Self::Params) -> Result<(), Error> {
+    async fn on_call(&mut self, params: Self::Call) -> Result<(), Error> {
         let () = params;
         Ok(())
     }
@@ -86,22 +86,22 @@ enum Message {
 impl ezsockets::SessionExt for CounterSession {
     type ID = SessionID;
     type Args = ();
-    type Params = Message;
+    type Call = Message;
 
     fn id(&self) -> &Self::ID {
         &self.id
     }
 
-    async fn text(&mut self, text: String) -> Result<(), Error> {
+    async fn on_text(&mut self, text: String) -> Result<(), Error> {
         self.handle.text(text);
         Ok(())
     }
 
-    async fn binary(&mut self, _bytes: Vec<u8>) -> Result<(), Error> {
+    async fn on_binary(&mut self, _bytes: Vec<u8>) -> Result<(), Error> {
         unimplemented!()
     }
 
-    async fn call(&mut self, params: Self::Params) -> Result<(), Error> {
+    async fn on_call(&mut self, params: Self::Call) -> Result<(), Error> {
         match params {
             Message::Increment => self.counter += 1,
             Message::Share => self.handle.text(format!("counter: {}", self.counter)),

--- a/examples/counter-server/src/main.rs
+++ b/examples/counter-server/src/main.rs
@@ -56,8 +56,8 @@ impl ezsockets::ServerExt for CounterServer {
         Ok(())
     }
 
-    async fn on_call(&mut self, params: Self::Call) -> Result<(), Error> {
-        let () = params;
+    async fn on_call(&mut self, call: Self::Call) -> Result<(), Error> {
+        let () = call;
         Ok(())
     }
 }
@@ -101,8 +101,8 @@ impl ezsockets::SessionExt for CounterSession {
         unimplemented!()
     }
 
-    async fn on_call(&mut self, params: Self::Call) -> Result<(), Error> {
-        match params {
+    async fn on_call(&mut self, call: Self::Call) -> Result<(), Error> {
+        match call {
             Message::Increment => self.counter += 1,
             Message::Share => self.handle.text(format!("counter: {}", self.counter)),
         };

--- a/examples/echo-server/src/main.rs
+++ b/examples/echo-server/src/main.rs
@@ -12,9 +12,9 @@ struct EchoServer {}
 #[async_trait]
 impl ezsockets::ServerExt for EchoServer {
     type Session = EchoSession;
-    type Params = ();
+    type Call = ();
 
-    async fn accept(
+    async fn on_connect(
         &mut self,
         socket: Socket,
         address: SocketAddr,
@@ -25,14 +25,14 @@ impl ezsockets::ServerExt for EchoServer {
         Ok(session)
     }
 
-    async fn disconnected(
+    async fn on_disconnect(
         &mut self,
         _id: <Self::Session as ezsockets::SessionExt>::ID,
     ) -> Result<(), Error> {
         Ok(())
     }
 
-    async fn call(&mut self, params: Self::Params) -> Result<(), Error> {
+    async fn on_call(&mut self, params: Self::Call) -> Result<(), Error> {
         let () = params;
         Ok(())
     }
@@ -47,22 +47,22 @@ struct EchoSession {
 impl ezsockets::SessionExt for EchoSession {
     type ID = SessionID;
     type Args = ();
-    type Params = ();
+    type Call = ();
 
     fn id(&self) -> &Self::ID {
         &self.id
     }
 
-    async fn text(&mut self, text: String) -> Result<(), Error> {
+    async fn on_text(&mut self, text: String) -> Result<(), Error> {
         self.handle.text(text);
         Ok(())
     }
 
-    async fn binary(&mut self, _bytes: Vec<u8>) -> Result<(), Error> {
+    async fn on_binary(&mut self, _bytes: Vec<u8>) -> Result<(), Error> {
         unimplemented!()
     }
 
-    async fn call(&mut self, params: Self::Params) -> Result<(), Error> {
+    async fn on_call(&mut self, params: Self::Call) -> Result<(), Error> {
         let () = params;
         Ok(())
     }

--- a/examples/echo-server/src/main.rs
+++ b/examples/echo-server/src/main.rs
@@ -32,8 +32,8 @@ impl ezsockets::ServerExt for EchoServer {
         Ok(())
     }
 
-    async fn on_call(&mut self, params: Self::Call) -> Result<(), Error> {
-        let () = params;
+    async fn on_call(&mut self, call: Self::Call) -> Result<(), Error> {
+        let () = call;
         Ok(())
     }
 }
@@ -62,8 +62,8 @@ impl ezsockets::SessionExt for EchoSession {
         unimplemented!()
     }
 
-    async fn on_call(&mut self, params: Self::Call) -> Result<(), Error> {
-        let () = params;
+    async fn on_call(&mut self, call: Self::Call) -> Result<(), Error> {
+        let () = call;
         Ok(())
     }
 }

--- a/examples/simple-client/src/main.rs
+++ b/examples/simple-client/src/main.rs
@@ -9,19 +9,19 @@ struct Client {}
 
 #[async_trait]
 impl ezsockets::ClientExt for Client {
-    type Params = ();
+    type Call = ();
 
-    async fn text(&mut self, text: String) -> Result<(), Error> {
+    async fn on_text(&mut self, text: String) -> Result<(), Error> {
         tracing::info!("received message: {text}");
         Ok(())
     }
 
-    async fn binary(&mut self, bytes: Vec<u8>) -> Result<(), Error> {
+    async fn on_binary(&mut self, bytes: Vec<u8>) -> Result<(), Error> {
         tracing::info!("received bytes: {bytes:?}");
         Ok(())
     }
 
-    async fn call(&mut self, params: Self::Params) -> Result<(), Error> {
+    async fn on_call(&mut self, params: Self::Call) -> Result<(), Error> {
         let () = params;
         Ok(())
     }

--- a/examples/simple-client/src/main.rs
+++ b/examples/simple-client/src/main.rs
@@ -21,8 +21,8 @@ impl ezsockets::ClientExt for Client {
         Ok(())
     }
 
-    async fn on_call(&mut self, params: Self::Call) -> Result<(), Error> {
-        let () = params;
+    async fn on_call(&mut self, call: Self::Call) -> Result<(), Error> {
+        let () = call;
         Ok(())
     }
 }

--- a/src/axum.rs
+++ b/src/axum.rs
@@ -12,7 +12,7 @@
 //! # struct MySession {}
 //! # #[async_trait]
 //! # impl ezsockets::SessionExt for MySession {
-//! #   type ID = u16; 
+//! #   type ID = u16;
 //! #   type Args = ();
 //! #   type Call = ();
 //! #   fn id(&self) -> &Self::ID { unimplemented!() }

--- a/src/axum.rs
+++ b/src/axum.rs
@@ -1,11 +1,36 @@
 //! `axum` feature must be enabled in order to use this module.
 //!
-//! ```ignore
+//! ```no_run
+//! # use axum_crate as axum;
+//! use async_trait::async_trait;
+//! use axum::routing::get;
+//! use axum::Extension;
+//! use axum::response::IntoResponse;
+//! use std::net::SocketAddr;
+//! use ezsockets::axum::Upgrade;
+//!
+//! # struct MySession {}
+//! # #[async_trait]
+//! # impl ezsockets::SessionExt for MySession {
+//! #   type ID = u16; 
+//! #   type Args = ();
+//! #   type Call = ();
+//! #   fn id(&self) -> &Self::ID { unimplemented!() }
+//! #   async fn on_text(&mut self, text: String) -> Result<(), ezsockets::Error> { unimplemented!() }
+//! #   async fn on_binary(&mut self, bytes: Vec<u8>) -> Result<(), ezsockets::Error> { unimplemented!() }
+//! #   async fn on_call(&mut self, call: Self::Call) -> Result<(), ezsockets::Error> { unimplemented!() }
+//! # }
+//! #
 //! struct EchoServer {}
 //!
 //! #[async_trait]
 //! impl ezsockets::ServerExt for EchoServer {
 //!     // ...
+//!    # type Session = MySession;
+//!    # type Call = ();
+//!    # async fn on_connect(&mut self, socket: ezsockets::Socket, address: std::net::SocketAddr, _args: ()) -> Result<ezsockets::Session<u16, ()>, ezsockets::Error> { unimplemented!() }
+//!    # async fn on_disconnect(&mut self, id: <Self::Session as ezsockets::SessionExt>::ID) -> Result<(), ezsockets::Error> { unimplemented!() }
+//!    # async fn on_call(&mut self, params: Self::Call) -> Result<(), ezsockets::Error> { unimplemented!() }
 //! }
 //!
 //! #[tokio::main]
@@ -28,12 +53,10 @@
 //! }
 //!
 //! async fn websocket_handler(
-//!     Extension(server): Extension<ezsockets::Server>,
+//!     Extension(server): Extension<ezsockets::Server<EchoServer>>,
 //!     ezsocket: Upgrade,
 //! ) -> impl IntoResponse {
-//!     ezsocket.on_upgrade(|socket, address| async move {
-//!         server.accept(socket, address, ()).await;
-//!     })
+//!     ezsocket.on_upgrade(server, ())
 //! }
 //! ```
 

--- a/src/axum.rs
+++ b/src/axum.rs
@@ -30,7 +30,7 @@
 //!    # type Call = ();
 //!    # async fn on_connect(&mut self, socket: ezsockets::Socket, address: std::net::SocketAddr, _args: ()) -> Result<ezsockets::Session<u16, ()>, ezsockets::Error> { unimplemented!() }
 //!    # async fn on_disconnect(&mut self, id: <Self::Session as ezsockets::SessionExt>::ID) -> Result<(), ezsockets::Error> { unimplemented!() }
-//!    # async fn on_call(&mut self, params: Self::Call) -> Result<(), ezsockets::Error> { unimplemented!() }
+//!    # async fn on_call(&mut self, call: Self::Call) -> Result<(), ezsockets::Error> { unimplemented!() }
 //! }
 //!
 //! #[tokio::main]

--- a/src/client.rs
+++ b/src/client.rs
@@ -11,20 +11,20 @@
 //!
 //! #[async_trait]
 //! impl ezsockets::ClientExt for Client {
-//!     type Params = ();
+//!     type Call = ();
 //!
-//!     async fn text(&mut self, text: String) -> Result<(), ezsockets::Error> {
+//!     async fn on_text(&mut self, text: String) -> Result<(), ezsockets::Error> {
 //!         tracing::info!("received message: {text}");
 //!         Ok(())
 //!     }
 //!
-//!     async fn binary(&mut self, bytes: Vec<u8>) -> Result<(), ezsockets::Error> {
+//!     async fn on_binary(&mut self, bytes: Vec<u8>) -> Result<(), ezsockets::Error> {
 //!         tracing::info!("received bytes: {bytes:?}");
 //!         Ok(())
 //!     }
 //!
-//!     async fn call(&mut self, params: Self::Params) -> Result<(), ezsockets::Error> {
-//!         let () = params;
+//!     async fn on_call(&mut self, call: Self::Call) -> Result<(), ezsockets::Error> {
+//!         let () = call;
 //!         Ok(())
 //!     }
 //! }

--- a/src/server.rs
+++ b/src/server.rs
@@ -260,20 +260,20 @@ impl<E: ServerExt> Server<E> {
             .unwrap();
     }
 
-    pub fn call(&self, params: E::Call) {
-        self.calls.send(params).map_err(|_| ()).unwrap();
+    pub fn call(&self, call: E::Call) {
+        self.calls.send(call).map_err(|_| ()).unwrap();
     }
 
     /// Calls a method on the session, allowing the Session to respond with oneshot::Sender.
-    /// This is just for easier construction of the Params which happen to contain oneshot::Sender in it.
+    /// This is just for easier construction of the call which happen to contain oneshot::Sender in it.
     pub async fn call_with<R: std::fmt::Debug>(
         &self,
         f: impl FnOnce(oneshot::Sender<R>) -> E::Call,
     ) -> R {
         let (sender, receiver) = oneshot::channel();
-        let params = f(sender);
+        let call = f(sender);
 
-        self.calls.send(params).unwrap();
+        self.calls.send(call).unwrap();
         receiver.await.unwrap()
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -46,7 +46,7 @@
 //! }
 //!
 //! // Create our own server that implements `ServerExt`
-//! 
+//!
 //! use ezsockets::Server;
 //! use ezsockets::Socket;
 //! use std::net::SocketAddr;

--- a/src/tungstenite.rs
+++ b/src/tungstenite.rs
@@ -1,22 +1,36 @@
 //! `tungstenite` feature must be enabled in order to use this module.
 //!
-//! ```ignore
-//! struct EchoServer {}
+//! ```no_run
+//! # use async_trait::async_trait;
+//! # struct MySession {}
+//! # #[async_trait::async_trait]
+//! # impl ezsockets::SessionExt for MySession {
+//! #   type ID = u16; 
+//! #   type Args = ();
+//! #   type Call = ();
+//! #   fn id(&self) -> &Self::ID { unimplemented!() }
+//! #   async fn on_text(&mut self, text: String) -> Result<(), ezsockets::Error> { unimplemented!() }
+//! #   async fn on_binary(&mut self, bytes: Vec<u8>) -> Result<(), ezsockets::Error> { unimplemented!() }
+//! #   async fn on_call(&mut self, call: Self::Call) -> Result<(), ezsockets::Error> { unimplemented!() }
+//! # }
+//! struct MyServer {}
 //!
 //! #[async_trait]
-//! impl ezsockets::ServerExt for EchoServer {
-//!     // ...
+//! impl ezsockets::ServerExt for MyServer {
+//!    // ...
+//!    # type Session = MySession;
+//!    # type Call = ();
+//!    # async fn on_connect(&mut self, socket: ezsockets::Socket, address: std::net::SocketAddr, _args: ()) -> Result<ezsockets::Session<u16, ()>, ezsockets::Error> { unimplemented!() }
+//!    # async fn on_disconnect(&mut self, id: <Self::Session as ezsockets::SessionExt>::ID) -> Result<(), ezsockets::Error> { unimplemented!() }
+//!    # async fn on_call(&mut self, params: Self::Call) -> Result<(), ezsockets::Error> { unimplemented!() }
 //! }
 //!
 //! #[tokio::main]
 //! async fn main() {
-//!     let (server, _) = ezsockets::Server::create(|_| EchoServer {});
-//!     ezsockets::tungstenite::run(server, "127.0.0.1:8080", |_socket| async move { Ok(()) })
-//!         .await
-//!         .unwrap();
+//!     let (server, _) = ezsockets::Server::create(|_| MyServer {});
+//!     ezsockets::tungstenite::run(server, "127.0.0.1:8080", |_socket| async move { Ok(()) }).await.unwrap();
 //! }
 //! ```
-//!
 
 use crate::socket::RawMessage;
 use crate::CloseCode;

--- a/src/tungstenite.rs
+++ b/src/tungstenite.rs
@@ -5,7 +5,7 @@
 //! # struct MySession {}
 //! # #[async_trait::async_trait]
 //! # impl ezsockets::SessionExt for MySession {
-//! #   type ID = u16; 
+//! #   type ID = u16;
 //! #   type Args = ();
 //! #   type Call = ();
 //! #   fn id(&self) -> &Self::ID { unimplemented!() }

--- a/src/tungstenite.rs
+++ b/src/tungstenite.rs
@@ -22,7 +22,7 @@
 //!    # type Call = ();
 //!    # async fn on_connect(&mut self, socket: ezsockets::Socket, address: std::net::SocketAddr, _args: ()) -> Result<ezsockets::Session<u16, ()>, ezsockets::Error> { unimplemented!() }
 //!    # async fn on_disconnect(&mut self, id: <Self::Session as ezsockets::SessionExt>::ID) -> Result<(), ezsockets::Error> { unimplemented!() }
-//!    # async fn on_call(&mut self, params: Self::Call) -> Result<(), ezsockets::Error> { unimplemented!() }
+//!    # async fn on_call(&mut self, call: Self::Call) -> Result<(), ezsockets::Error> { unimplemented!() }
 //! }
 //!
 //! #[tokio::main]

--- a/tests/chat.rs
+++ b/tests/chat.rs
@@ -82,8 +82,8 @@ impl ezsockets::ServerExt for ChatServer {
         Ok(())
     }
 
-    async fn on_call(&mut self, params: Self::Call) -> Result<(), Error> {
-        match params {
+    async fn on_call(&mut self, call: Self::Call) -> Result<(), Error> {
+        match call {
             Message::Send { from, room, text } => {
                 let (ids, sessions): (Vec<SessionID>, Vec<&Session>) = self
                     .rooms
@@ -191,8 +191,8 @@ impl ezsockets::SessionExt for SessionActor {
         unimplemented!()
     }
 
-    async fn on_call(&mut self, params: Self::Call) -> Result<(), Error> {
-        let () = params;
+    async fn on_call(&mut self, call: Self::Call) -> Result<(), Error> {
+        let () = call;
         Ok(())
     }
 }
@@ -237,8 +237,8 @@ impl ezsockets::ClientExt for ChatClient {
         Ok(())
     }
 
-    async fn on_call(&mut self, params: Self::Call) -> Result<(), ezsockets::Error> {
-        match params {
+    async fn on_call(&mut self, call: Self::Call) -> Result<(), ezsockets::Error> {
+        match call {
             ChatClientMessage::Send(message) => self.handle.text(message),
             ChatClientMessage::Subscribe(respond_to) => {
                 respond_to.send(self.messages.subscribe()).unwrap()


### PR DESCRIPTION
closes #19 
Changes:
|Before|After|
|:------|:-----|
|`ClientExt::Params`| `ClientExt::Call`|
|`ClientExt::text(...)`| `ClientExt::on_text(...)`|
|`ClientExt::binary(...)`| `ClientExt::on_binary(...)`|
|`ClientExt::call(...)`| `ClientExt::on_call(...)`|
|`ClientExt::connected(...)`| `ClientExt::on_connected(...)`|
|`ClientExt::closed(...)`| `ClientExt::closed(...)`|
|-|-|
|`ServerExt::Params`| `ServerExt::Call`|
|`ServerExt::accept(...)`| `ServerExt::on_connect(...)`|
|`ServerExt::disconnected(...)`| `ServerExt::on_disconnect(...)`|
|`ServerExt::call(...)`| `ServerExt::on_call(...)`|
|-|-|
|`SessionExt::Params`| `SessionExt::Call`|
|`SessionExt::text(...)`| `SessionExt::on_text(...)`|
|`SessionExt::binary(...)`| `SessionExt::on_binary(...)`|
|`SessionExt::call(...)`| `SessionExt::on_call(...)`|