### PR TITLE
Improve connection rejection handling for ServerExt::on_connect()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - change `Client::close` to use reference instead of `self`
 - feat: loosen `std::fmt::Debug` constrain on `Call` by @qiujiangkun in https://github.com/gbaranski/ezsockets/pull/39
 - refactor: replace `SessionExt::Args` with `http::Request` by @qiujiangkun and @gbaranski in https://github.com/gbaranski/ezsockets/pull/42
+- fix server bug that would cause the server to crash if `ServerExt::on_connect()` returned an error
+- return `Err(Option<CloseFrame>)` from `ServerExt::on_connect()` to reject connections
 
 
 Migration guide:
@@ -34,7 +36,7 @@ impl ezsockets::ServerExt for ChatServer {
         request: ezsockets::Request, // <----- 3. Add `request: ezsockets::Request` argument.
         //                                        Note: `ezsockets::Request` is an alias for `http::Request`
         address: SocketAddr,
-    ) -> Result<Session, Error> { todo!() }
+    ) -> Result<Session, Option<CloseFrame>> { todo!() } // <----- 4. Return `CloseFrame` if rejecting connection.
     
     // ...
 }
@@ -48,7 +50,7 @@ async fn websocket_handler(
 ) -> impl IntoResponse {
     let session_args = get_session_args();
     // before:
-        ezsocket.on_upgrade(server, session_args) // <----- 4. Remove `session_args` argument
+        ezsocket.on_upgrade(server, session_args) // <----- 5. Remove `session_args` argument
     // after:
         ezsocket.on_upgrade(server)               // <----- Now you can customize the `Session` inside of `ServerExt::on_connect` via `ezsockets::Request`
 }
@@ -59,7 +61,7 @@ async fn websocket_handler(
 ezsockets::tungstenite::run(
     server, 
     "127.0.0.1:8080", 
-    |_| async move { Ok(()) } // <----- 5. Remove the last argument, 
+    |_| async move { Ok(()) } // <----- 6. Remove the last argument, 
                               // Now you can customize the `Session` inside of `ServerExt::on_connect` via `ezsockets::Request`
 ).await.unwrap();
 

--- a/benches/ezsockets_server.rs
+++ b/benches/ezsockets_server.rs
@@ -18,7 +18,7 @@ impl ezsockets::ServerExt for EchoServer {
         socket: ezsockets::Socket,
         _request: ezsockets::Request,
         address: SocketAddr,
-    ) -> Result<Session, ezsockets::Error> {
+    ) -> Result<Session, Option<ezsockets::CloseFrame>> {
         let id = address.port();
         let session = Session::create(|handle| EchoSession { id, handle }, id, socket);
         Ok(session)

--- a/examples/chat-server-axum/src/main.rs
+++ b/examples/chat-server-axum/src/main.rs
@@ -5,6 +5,7 @@ use axum::response::IntoResponse;
 use axum::routing::get;
 use axum::Router;
 use ezsockets::axum::Upgrade;
+use ezsockets::CloseFrame;
 use ezsockets::Error;
 use ezsockets::Server;
 use std::collections::HashMap;
@@ -34,7 +35,7 @@ impl ezsockets::ServerExt for ChatServer {
         socket: ezsockets::Socket,
         _request: ezsockets::Request,
         _address: SocketAddr,
-    ) -> Result<Session, Error> {
+    ) -> Result<Session, Option<CloseFrame>> {
         let id = (0..).find(|i| !self.sessions.contains_key(i)).unwrap_or(0);
         let session = Session::create(
             |_| ChatSession {

--- a/examples/chat-server/src/main.rs
+++ b/examples/chat-server/src/main.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use ezsockets::CloseFrame;
 use ezsockets::Error;
 use ezsockets::Server;
 use std::collections::HashMap;
@@ -38,7 +39,7 @@ impl ezsockets::ServerExt for ChatServer {
         socket: ezsockets::Socket,
         _request: ezsockets::Request,
         _address: SocketAddr,
-    ) -> Result<Session, Error> {
+    ) -> Result<Session, Option<CloseFrame>> {
         let id = (0..).find(|i| !self.sessions.contains_key(i)).unwrap_or(0);
         let session = Session::create(
             |_handle| SessionActor {

--- a/examples/counter-server/src/main.rs
+++ b/examples/counter-server/src/main.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use ezsockets::CloseFrame;
 use ezsockets::Error;
 use ezsockets::Server;
 use std::net::SocketAddr;
@@ -21,7 +22,7 @@ impl ezsockets::ServerExt for CounterServer {
         socket: ezsockets::Socket,
         _request: ezsockets::Request,
         address: SocketAddr,
-    ) -> Result<Session, Error> {
+    ) -> Result<Session, Option<CloseFrame>> {
         let id = address.port();
         let session = Session::create(
             |handle| {

--- a/examples/echo-server-native-tls/src/main.rs
+++ b/examples/echo-server-native-tls/src/main.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use ezsockets::CloseFrame;
 use ezsockets::Error;
 use ezsockets::Server;
 use native_tls::Identity;
@@ -20,7 +21,7 @@ impl ezsockets::ServerExt for EchoServer {
         socket: ezsockets::Socket,
         _request: ezsockets::Request,
         address: SocketAddr,
-    ) -> Result<Session, Error> {
+    ) -> Result<Session, Option<CloseFrame>> {
         let id = address.port();
         let session = Session::create(|handle| EchoSession { id, handle }, id, socket);
         Ok(session)

--- a/examples/echo-server/src/main.rs
+++ b/examples/echo-server/src/main.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use ezsockets::CloseFrame;
 use ezsockets::Error;
 use ezsockets::Request;
 use ezsockets::Server;
@@ -20,7 +21,7 @@ impl ezsockets::ServerExt for EchoServer {
         socket: Socket,
         _request: Request,
         address: SocketAddr,
-    ) -> Result<Session, Error> {
+    ) -> Result<Session, Option<CloseFrame>> {
         let id = address.port();
         let session = Session::create(|handle| EchoSession { id, handle }, id, socket);
         Ok(session)

--- a/src/axum.rs
+++ b/src/axum.rs
@@ -27,7 +27,7 @@
 //!     // ...
 //!    # type Session = MySession;
 //!    # type Call = ();
-//!    # async fn on_connect(&mut self, socket: ezsockets::Socket, request: ezsockets::Request, address: std::net::SocketAddr) -> Result<ezsockets::Session<u16, ()>, ezsockets::Error> { unimplemented!() }
+//!    # async fn on_connect(&mut self, socket: ezsockets::Socket, request: ezsockets::Request, address: std::net::SocketAddr) -> Result<ezsockets::Session<u16, ()>, Option<ezsockets::CloseFrame>> { unimplemented!() }
 //!    # async fn on_disconnect(&mut self, id: <Self::Session as ezsockets::SessionExt>::ID) -> Result<(), ezsockets::Error> { unimplemented!() }
 //!    # async fn on_call(&mut self, call: Self::Call) -> Result<(), ezsockets::Error> { unimplemented!() }
 //! }

--- a/src/server.rs
+++ b/src/server.rs
@@ -61,7 +61,7 @@
 //!         socket: ezsockets::Socket,
 //!         request: ezsockets::Request,
 //!         address: SocketAddr,
-//!     ) -> Result<Session, ezsockets::Error> {
+//!     ) -> Result<Session, Option<ezsockets::CloseFrame>> {
 //!         let id = address.port();
 //!         let session = Session::create(|handle| EchoSession { id, handle }, id, socket);
 //!         Ok(session)
@@ -87,6 +87,7 @@
 
 use crate::CloseFrame;
 use crate::Error;
+use crate::Message;
 use crate::Request;
 use crate::Session;
 use crate::SessionExt;
@@ -97,11 +98,11 @@ use tokio::sync::mpsc;
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 
-struct NewConnection<E: ServerExt> {
+struct NewConnection {
     socket: Socket,
     address: SocketAddr,
     request: Request,
-    respond_to: oneshot::Sender<<E::Session as SessionExt>::ID>,
+    respond_to: oneshot::Sender<()>,
 }
 
 struct Disconnected<E: ServerExt> {
@@ -110,7 +111,7 @@ struct Disconnected<E: ServerExt> {
 }
 
 struct ServerActor<E: ServerExt> {
-    connections: mpsc::UnboundedReceiver<NewConnection<E>>,
+    connections: mpsc::UnboundedReceiver<NewConnection>,
     disconnections: mpsc::UnboundedReceiver<Disconnected<E>>,
     calls: mpsc::UnboundedReceiver<E::Call>,
     server: Server<E>,
@@ -128,18 +129,27 @@ where
             if let Err(err) = async {
                 tokio::select! {
                     Some(NewConnection{socket, address, respond_to, request}) = self.connections.recv() => {
-                        let session = self.extension.on_connect(socket, request, address).await?;
-                        let session_id = session.id.clone();
-                        tracing::info!("connection from {address} accepted");
-                        respond_to.send(session_id.clone()).unwrap();
+                        let socket_sink = socket.sink.clone();
+                        match self.extension.on_connect(socket, request, address).await {
+                            Ok(session) => {
+                                tracing::info!("connection from {address} accepted");
+                                let session_id = session.id.clone();
 
-                        tokio::spawn({
-                            let server = self.server.clone();
-                            async move {
-                                let result = session.closed().await;
-                                server.disconnected(session_id, result).await;
+                                tokio::spawn({
+                                    let server = self.server.clone();
+                                    async move {
+                                        let result = session.closed().await;
+                                        server.disconnected(session_id, result).await;
+                                    }
+                                });
                             }
-                        });
+                            Err(err) => {
+                                // our extension rejected the connection, so forward the close frame to the client
+                                tracing::info!(?err, "connection from {address} rejected");
+                                socket_sink.send(Message::Close(err)).await;
+                            }
+                        }
+                        respond_to.send(()).unwrap_or_default();
                     }
                     Some(Disconnected{id, result}) = self.disconnections.recv() => {
                         self.extension.on_disconnect(id.clone()).await?;
@@ -181,7 +191,7 @@ pub trait ServerExt: Send {
         address: SocketAddr,
     ) -> Result<
         Session<<Self::Session as SessionExt>::ID, <Self::Session as SessionExt>::Call>,
-        Error,
+        Option<CloseFrame>,
     >;
     /// Called when client disconnects from the server.
     async fn on_disconnect(&mut self, id: <Self::Session as SessionExt>::ID) -> Result<(), Error>;
@@ -192,7 +202,7 @@ pub trait ServerExt: Send {
 
 #[derive(Debug)]
 pub struct Server<E: ServerExt> {
-    connections: mpsc::UnboundedSender<NewConnection<E>>,
+    connections: mpsc::UnboundedSender<NewConnection>,
     disconnections: mpsc::UnboundedSender<Disconnected<E>>,
     calls: mpsc::UnboundedSender<E::Call>,
 }
@@ -228,12 +238,7 @@ impl<E: ServerExt + 'static> Server<E> {
 }
 
 impl<E: ServerExt> Server<E> {
-    pub async fn accept(
-        &self,
-        socket: Socket,
-        request: Request,
-        address: SocketAddr,
-    ) -> <E::Session as SessionExt>::ID {
+    pub async fn accept(&self, socket: Socket, request: Request, address: SocketAddr) {
         // TODO: can we refuse the connection here?
         let (sender, receiver) = oneshot::channel();
         self.connections
@@ -245,7 +250,7 @@ impl<E: ServerExt> Server<E> {
             })
             .map_err(|_| "connections is down")
             .unwrap();
-        receiver.await.unwrap()
+        receiver.await.unwrap_or_default()
     }
 
     pub(crate) async fn disconnected(

--- a/src/tungstenite.rs
+++ b/src/tungstenite.rs
@@ -19,7 +19,7 @@
 //!    // ...
 //!    # type Session = MySession;
 //!    # type Call = ();
-//!    # async fn on_connect(&mut self, socket: ezsockets::Socket, request: ezsockets::Request, address: std::net::SocketAddr) -> Result<ezsockets::Session<u16, ()>, ezsockets::Error> { unimplemented!() }
+//!    # async fn on_connect(&mut self, socket: ezsockets::Socket, request: ezsockets::Request, address: std::net::SocketAddr) -> Result<ezsockets::Session<u16, ()>, Option<ezsockets::CloseFrame>> { unimplemented!() }
 //!    # async fn on_disconnect(&mut self, id: <Self::Session as ezsockets::SessionExt>::ID) -> Result<(), ezsockets::Error> { unimplemented!() }
 //!    # async fn on_call(&mut self, call: Self::Call) -> Result<(), ezsockets::Error> { unimplemented!() }
 //! }

--- a/tests/chat.rs
+++ b/tests/chat.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use ezsockets::CloseFrame;
 use ezsockets::Error;
 use ezsockets::Request;
 use ezsockets::Server;
@@ -52,7 +53,7 @@ impl ezsockets::ServerExt for ChatServer {
         socket: Socket,
         request: Request,
         _address: SocketAddr,
-    ) -> Result<Session, Error> {
+    ) -> Result<Session, Option<CloseFrame>> {
         let value = request.headers().get("Some-Header").unwrap();
         assert_eq!(value, "someValue");
         let id = (0..).find(|i| !self.sessions.contains_key(i)).unwrap_or(0);


### PR DESCRIPTION
### Problem

Currently the only way for the server to reject a connection is to return an error from `ServerExt::on_connect()`. However, doing so causes `Server::accept()` to panic, which crashes the server.

### Solution

The solution here is to send a close frame to the socket via `on_connect()`. This has the added benefit that clients will obtain the closure reason.

I also removed the return value from `Server::accept()` since it wasn't being used anywhere.

### Future Work
- The client needs to receive close frames in `ClientExt::on_disconnect()`.