### PR TITLE
Remove panics from Client interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - fix server bug that would cause the server to crash if `ServerExt::on_connect()` returned an error
 - return `Err(Option<CloseFrame>)` from `ServerExt::on_connect()` to reject connections
 - robustness: `Server` interface now returns `Result<(), tokio::sync::mpsc::error::SendError>` instead of potentially panicking
+- robustness: `Client` interface now returns `Result<(), tokio::sync::mpsc::error::SendError>` instead of potentially panicking
 
 
 Migration guide:

--- a/examples/chat-client/src/main.rs
+++ b/examples/chat-client/src/main.rs
@@ -37,6 +37,6 @@ async fn main() {
     for line in lines {
         let line = line.unwrap();
         tracing::info!("sending {line}");
-        handle.text(line);
+        handle.text(line).unwrap();
     }
 }

--- a/examples/simple-client/src/main.rs
+++ b/examples/simple-client/src/main.rs
@@ -33,14 +33,16 @@ impl ezsockets::ClientExt for Client {
             Call::NewLine(line) => {
                 if line == "exit" {
                     tracing::info!("exiting...");
-                    self.handle.close(Some(CloseFrame {
-                        code: CloseCode::Normal,
-                        reason: "adios!".to_string(),
-                    }));
+                    self.handle
+                        .close(Some(CloseFrame {
+                            code: CloseCode::Normal,
+                            reason: "adios!".to_string(),
+                        }))
+                        .unwrap();
                     return Ok(());
                 }
                 tracing::info!("sending {line}");
-                self.handle.text(line);
+                self.handle.text(line).unwrap();
             }
         };
         Ok(())
@@ -62,7 +64,7 @@ async fn main() {
         let lines = stdin.lock().lines();
         for line in lines {
             let line = line.unwrap();
-            handle.call(Call::NewLine(line));
+            handle.call(Call::NewLine(line)).unwrap();
         }
     });
     future.await.unwrap();


### PR DESCRIPTION
### Problem

The `Client` interface can panic if the `ClientActor` runner errors out. You can check liveness of the actor via its future returned from `connect()`, but there is a race condition after that.

### Solution

Don't panic if the actor is dead.