### PR TITLE
Remove panics from Session interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - return `Err(Option<CloseFrame>)` from `ServerExt::on_connect()` to reject connections
 - robustness: `Server` interface now returns `Result<(), tokio::sync::mpsc::error::SendError>` instead of potentially panicking
 - robustness: `Client` interface now returns `Result<(), tokio::sync::mpsc::error::SendError>` instead of potentially panicking
+- robustness: `Session` interface now returns `Result<(), tokio::sync::mpsc::error::SendError>` instead of potentially panicking
 
 
 Migration guide:

--- a/benches/ezsockets_server.rs
+++ b/benches/ezsockets_server.rs
@@ -52,7 +52,7 @@ impl ezsockets::SessionExt for EchoSession {
     }
 
     async fn on_text(&mut self, text: String) -> Result<(), ezsockets::Error> {
-        self.handle.text(text);
+        self.handle.text(text).unwrap();
         Ok(())
     }
 

--- a/examples/chat-server-axum/src/main.rs
+++ b/examples/chat-server-axum/src/main.rs
@@ -64,7 +64,7 @@ impl ezsockets::ServerExt for ChatServer {
                 let text = format!("from {from}: {text}");
                 for (id, handle) in sessions {
                     tracing::info!("sending {text} to {id}");
-                    handle.text(text.clone());
+                    handle.text(text.clone()).unwrap();
                 }
             }
         };

--- a/examples/chat-server/src/main.rs
+++ b/examples/chat-server/src/main.rs
@@ -91,7 +91,7 @@ impl ezsockets::ServerExt for ChatServer {
                         .join(",")
                 );
                 for session in sessions {
-                    session.text(text.clone());
+                    session.text(text.clone()).unwrap();
                 }
             }
             Message::Join { id, room } => {
@@ -115,7 +115,9 @@ impl ezsockets::ServerExt for ChatServer {
                     .map(|id| self.sessions.get(id).unwrap());
 
                 for session in sessions {
-                    session.text(format!("User with ID: {id} just joined {room} room"));
+                    session
+                        .text(format!("User with ID: {id} just joined {room} room"))
+                        .unwrap();
                 }
             }
         };

--- a/examples/counter-server/src/main.rs
+++ b/examples/counter-server/src/main.rs
@@ -30,8 +30,8 @@ impl ezsockets::ServerExt for CounterServer {
                     let session = handle.clone();
                     async move {
                         loop {
-                            session.call(Message::Increment);
-                            session.call(Message::Share);
+                            session.call(Message::Increment).unwrap();
+                            session.call(Message::Share).unwrap();
                             tokio::time::sleep(INTERVAL).await;
                         }
                     }
@@ -92,7 +92,7 @@ impl ezsockets::SessionExt for CounterSession {
     }
 
     async fn on_text(&mut self, text: String) -> Result<(), Error> {
-        self.handle.text(text);
+        self.handle.text(text).unwrap();
         Ok(())
     }
 
@@ -103,7 +103,10 @@ impl ezsockets::SessionExt for CounterSession {
     async fn on_call(&mut self, call: Self::Call) -> Result<(), Error> {
         match call {
             Message::Increment => self.counter += 1,
-            Message::Share => self.handle.text(format!("counter: {}", self.counter)),
+            Message::Share => self
+                .handle
+                .text(format!("counter: {}", self.counter))
+                .unwrap(),
         };
         Ok(())
     }

--- a/examples/echo-server-native-tls/src/main.rs
+++ b/examples/echo-server-native-tls/src/main.rs
@@ -55,7 +55,7 @@ impl ezsockets::SessionExt for EchoSession {
     }
 
     async fn on_text(&mut self, text: String) -> Result<(), Error> {
-        self.handle.text(text);
+        self.handle.text(text).unwrap();
         Ok(())
     }
 

--- a/examples/echo-server/src/main.rs
+++ b/examples/echo-server/src/main.rs
@@ -55,7 +55,7 @@ impl ezsockets::SessionExt for EchoSession {
     }
 
     async fn on_text(&mut self, text: String) -> Result<(), Error> {
-        self.handle.text(text);
+        self.handle.text(text).unwrap();
         Ok(())
     }
 

--- a/tests/chat.rs
+++ b/tests/chat.rs
@@ -107,7 +107,7 @@ impl ezsockets::ServerExt for ChatServer {
                         .join(",")
                 );
                 for session in sessions {
-                    session.text(text.clone());
+                    session.text(text.clone()).unwrap();
                 }
             }
             Message::Join {
@@ -138,7 +138,9 @@ impl ezsockets::ServerExt for ChatServer {
 
                 respond_to.send(()).unwrap();
                 for session in sessions {
-                    session.text(format!("User with ID: {id} just joined {room} room"));
+                    session
+                        .text(format!("User with ID: {id} just joined {room} room"))
+                        .unwrap();
                 }
             }
         };


### PR DESCRIPTION
### Problem

The `Session` interface can panic if the `SessionActor` runner errors out. You can check liveness of the actor via `Session::alive()`, but there is a race condition after that.

### Solution

Don't panic if the actor is dead.