### PR TITLE
Remove 'async' from functions where it's not needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## v0.6.0 BREAKING
 
-- change `Client::close` to use reference instead of `self`
+- change `Client::close()` to use reference instead of `self`; remove `async` qualifier
 - feat: loosen `std::fmt::Debug` constrain on `Call` by @qiujiangkun in https://github.com/gbaranski/ezsockets/pull/39
 - refactor: replace `SessionExt::Args` with `http::Request` by @qiujiangkun and @gbaranski in https://github.com/gbaranski/ezsockets/pull/42
 

--- a/examples/simple-client/src/main.rs
+++ b/examples/simple-client/src/main.rs
@@ -33,12 +33,10 @@ impl ezsockets::ClientExt for Client {
             Call::NewLine(line) => {
                 if line == "exit" {
                     tracing::info!("exiting...");
-                    self.handle
-                        .close(Some(CloseFrame {
-                            code: CloseCode::Normal,
-                            reason: "adios!".to_string(),
-                        }))
-                        .await;
+                    self.handle.close(Some(CloseFrame {
+                        code: CloseCode::Normal,
+                        reason: "adios!".to_string(),
+                    }));
                     return Ok(());
                 }
                 tracing::info!("sending {line}");

--- a/src/client.rs
+++ b/src/client.rs
@@ -240,7 +240,7 @@ impl<E: ClientExt> Client<E> {
     /// Disconnect client from the server.
     /// Optionally pass a frame with reason and code.
     /// The client **must not** be used after this method is called.
-    pub async fn close(&self, frame: Option<CloseFrame>) {
+    pub fn close(&self, frame: Option<CloseFrame>) {
         self.socket.send(Message::Close(frame)).unwrap();
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -137,7 +137,7 @@ where
                             let server = self.server.clone();
                             async move {
                                 let result = session.closed().await;
-                                server.disconnected(session_id, result).await;
+                                server.disconnected(session_id, result);
                             }
                         });
                     }
@@ -248,7 +248,7 @@ impl<E: ServerExt> Server<E> {
         receiver.await.unwrap()
     }
 
-    pub(crate) async fn disconnected(
+    pub(crate) fn disconnected(
         &self,
         id: <E::Session as SessionExt>::ID,
         result: Result<Option<CloseFrame>, Error>,


### PR DESCRIPTION
### Problem

`Client::close()` is marked `async` and doesn't use it. This means it's hard to actually close a client when not in a tokio runtime, since you can only pass clients by value into an async closure.

### Solution

Remove unused `async` markers.
