### PR TITLE
Add Session::close() method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - change `Client::close` to use reference instead of `self`
 - feat: loosen `std::fmt::Debug` constrain on `Call` by @qiujiangkun in https://github.com/gbaranski/ezsockets/pull/39
 - refactor: replace `SessionExt::Args` with `http::Request` by @qiujiangkun and @gbaranski in https://github.com/gbaranski/ezsockets/pull/42
+- add `Session::close()` method
 
 
 Migration guide:

--- a/src/session.rs
+++ b/src/session.rs
@@ -135,6 +135,11 @@ impl<I: std::fmt::Display + Clone, C> Session<I, C> {
         self.calls.send(call).map_err(|_| ()).unwrap();
         receiver.await.unwrap()
     }
+
+    /// Close the session. Returns an error if the session is already closed.
+    pub async fn close(&self, frame: Option<CloseFrame>) -> Result<(), ()> {
+        self.socket.send(Message::Close(frame)).map_err(|_| ())
+    }
 }
 
 pub(crate) struct SessionActor<E: SessionExt> {


### PR DESCRIPTION
### Problem

Currently the only way for `ServerExt` to close a session is to A) own a handle to the session sink and send in a close frame (this closes the session socket), and B) return an error from `on_call()` (this forces the session to close).

### Solution

Add a `Session::close()` method that takes a close frame.