### PR TITLE
Improve client close handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - change `Client::close` to use reference instead of `self`
 - feat: loosen `std::fmt::Debug` constrain on `Call` by @qiujiangkun in https://github.com/gbaranski/ezsockets/pull/39
 - refactor: replace `SessionExt::Args` with `http::Request` by @qiujiangkun and @gbaranski in https://github.com/gbaranski/ezsockets/pull/42
+- add `ClientExt::on_disconnect()` for socket closure and return a `ClientCloseCode` from `ClientExt::on_close()/on_disconnect()` to control reconnect/full-close behavior
 
 
 Migration guide:


### PR DESCRIPTION
### Problem

In order for `ClientExt` to fully close the client, it must return an error from `ClientExt::on_close()`. Otherwise the `ClientActor` will try to reconnect.

Also, there is no differentiation between closure due to a server `Close` message or closure due to the socket dying.

### Solution

- Add `ClientExt::on_disconnect()` for handling socket death.
- Return a `ClientCloseCode` from `ClientExt::on_close/on_disconnect()` to specify reconnect/full-close behavior.
- Pass the server's close frame to `ClientExt::on_close()`.