### PR TITLE
Add disconnect reason to ServerExt::on_disconnect()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - fix server bug that would cause the server to crash if `ServerExt::on_connect()` returned an error
 - return `Err(Option<CloseFrame>)` from `ServerExt::on_connect()` to reject connections
 - robustness: `Server`, `Client`, `Session`, `Sink` interfaces now return `Result<(), tokio::sync::mpsc::error::SendError>` instead of potentially panicking
+- add reason to `ServerExt::on_disconnect()`
 
 
 Migration guide:

--- a/benches/ezsockets_server.rs
+++ b/benches/ezsockets_server.rs
@@ -27,6 +27,7 @@ impl ezsockets::ServerExt for EchoServer {
     async fn on_disconnect(
         &mut self,
         _id: <Self::Session as ezsockets::SessionExt>::ID,
+        _reason: Result<Option<ezsockets::CloseFrame>, ezsockets::Error>,
     ) -> Result<(), ezsockets::Error> {
         Ok(())
     }

--- a/examples/chat-server-axum/src/main.rs
+++ b/examples/chat-server-axum/src/main.rs
@@ -52,6 +52,7 @@ impl ezsockets::ServerExt for ChatServer {
     async fn on_disconnect(
         &mut self,
         id: <Self::Session as ezsockets::SessionExt>::ID,
+        _reason: Result<Option<CloseFrame>, Error>,
     ) -> Result<(), Error> {
         assert!(self.sessions.remove(&id).is_some());
         Ok(())

--- a/examples/chat-server/src/main.rs
+++ b/examples/chat-server/src/main.rs
@@ -58,6 +58,7 @@ impl ezsockets::ServerExt for ChatServer {
     async fn on_disconnect(
         &mut self,
         id: <Self::Session as ezsockets::SessionExt>::ID,
+        _reason: Result<Option<CloseFrame>, Error>,
     ) -> Result<(), Error> {
         assert!(self.sessions.remove(&id).is_some());
 

--- a/examples/counter-server/src/main.rs
+++ b/examples/counter-server/src/main.rs
@@ -52,6 +52,7 @@ impl ezsockets::ServerExt for CounterServer {
     async fn on_disconnect(
         &mut self,
         _id: <Self::Session as ezsockets::SessionExt>::ID,
+        _reason: Result<Option<CloseFrame>, Error>,
     ) -> Result<(), Error> {
         Ok(())
     }

--- a/examples/echo-server-native-tls/src/main.rs
+++ b/examples/echo-server-native-tls/src/main.rs
@@ -30,6 +30,7 @@ impl ezsockets::ServerExt for EchoServer {
     async fn on_disconnect(
         &mut self,
         _id: <Self::Session as ezsockets::SessionExt>::ID,
+        _reason: Result<Option<CloseFrame>, Error>,
     ) -> Result<(), Error> {
         Ok(())
     }

--- a/examples/echo-server/src/main.rs
+++ b/examples/echo-server/src/main.rs
@@ -30,6 +30,7 @@ impl ezsockets::ServerExt for EchoServer {
     async fn on_disconnect(
         &mut self,
         _id: <Self::Session as ezsockets::SessionExt>::ID,
+        _reason: Result<Option<CloseFrame>, Error>,
     ) -> Result<(), Error> {
         Ok(())
     }

--- a/src/axum.rs
+++ b/src/axum.rs
@@ -28,7 +28,7 @@
 //!    # type Session = MySession;
 //!    # type Call = ();
 //!    # async fn on_connect(&mut self, socket: ezsockets::Socket, request: ezsockets::Request, address: std::net::SocketAddr) -> Result<ezsockets::Session<u16, ()>, Option<ezsockets::CloseFrame>> { unimplemented!() }
-//!    # async fn on_disconnect(&mut self, id: <Self::Session as ezsockets::SessionExt>::ID) -> Result<(), ezsockets::Error> { unimplemented!() }
+//!    # async fn on_disconnect(&mut self, id: <Self::Session as ezsockets::SessionExt>::ID, reason: Result<Option<ezsockets::CloseFrame>, ezsockets::Error>) -> Result<(), ezsockets::Error> { unimplemented!() }
 //!    # async fn on_call(&mut self, call: Self::Call) -> Result<(), ezsockets::Error> { unimplemented!() }
 //! }
 //!

--- a/src/tungstenite.rs
+++ b/src/tungstenite.rs
@@ -20,7 +20,7 @@
 //!    # type Session = MySession;
 //!    # type Call = ();
 //!    # async fn on_connect(&mut self, socket: ezsockets::Socket, request: ezsockets::Request, address: std::net::SocketAddr) -> Result<ezsockets::Session<u16, ()>, Option<ezsockets::CloseFrame>> { unimplemented!() }
-//!    # async fn on_disconnect(&mut self, id: <Self::Session as ezsockets::SessionExt>::ID) -> Result<(), ezsockets::Error> { unimplemented!() }
+//!    # async fn on_disconnect(&mut self, id: <Self::Session as ezsockets::SessionExt>::ID, reason: Result<Option<ezsockets::CloseFrame>, ezsockets::Error>) -> Result<(), ezsockets::Error> { unimplemented!() }
 //!    # async fn on_call(&mut self, call: Self::Call) -> Result<(), ezsockets::Error> { unimplemented!() }
 //! }
 //!

--- a/tests/chat.rs
+++ b/tests/chat.rs
@@ -74,6 +74,7 @@ impl ezsockets::ServerExt for ChatServer {
     async fn on_disconnect(
         &mut self,
         id: <Self::Session as ezsockets::SessionExt>::ID,
+        _reason: Result<Option<CloseFrame>, Error>,
     ) -> Result<(), Error> {
         assert!(self.sessions.remove(&id).is_some());
 


### PR DESCRIPTION
### Problem

`ServerExt::on_disconnect()` has no exposure to the reason for disconnect.

### Solution

Pass the disconnect reason to `on_disconnect()`.