### PR TITLE
Pass close frame from socket to socket owner

### DIFF
--- a/src/socket.rs
+++ b/src/socket.rs
@@ -270,7 +270,7 @@ where
 
                         continue;
                     }
-                    RawMessage::Close(_) => return,
+                    RawMessage::Close(frame) => Message::Close(frame),
                 }),
                 Err(err) => Err(err), // maybe early return here?
             };


### PR DESCRIPTION
### Problem

Returning when a socket receives a close frame causes the socket to close without performing a close handshake (which is a websockets protocol error). If a server closes a session, then the corresponding client will get disconnected instead of receiving a close frame.

### Solution

Forward the close frame to the socket owner. The owning session/client will then shut down, which will cause the socket to be dropped (except for clients that may choose to reconnect instead).
