### PR TITLE
Fix heartbeat future in socket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - add `Session::close()` method
 - fix server bug that would cause the server to crash if `ServerExt::on_connect()` returned an error
 - return `Err(Option<CloseFrame>)` from `ServerExt::on_connect()` to reject connections
-- robustness: `Server` interface now returns `Result<(), tokio::sync::mpsc::error::SendError>` instead of potentially panicking
-- robustness: `Client` interface now returns `Result<(), tokio::sync::mpsc::error::SendError>` instead of potentially panicking
-- robustness: `Session` interface now returns `Result<(), tokio::sync::mpsc::error::SendError>` instead of potentially panicking
-- robustness: remove panics from `Sink` API
+- robustness: `Server`, `Client`, `Session`, `Sink` interfaces now return `Result<(), tokio::sync::mpsc::error::SendError>` instead of potentially panicking
 
 
 Migration guide:

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -349,7 +349,13 @@ impl Socket {
                         .unwrap();
                     let timestamp = timestamp.as_millis();
                     let bytes = timestamp.to_be_bytes();
-                    let _ = sink.send_raw(RawMessage::Ping(bytes.to_vec())).await;
+                    if sink
+                        .send_raw(RawMessage::Ping(bytes.to_vec()))
+                        .await
+                        .is_err()
+                    {
+                        break;
+                    }
                 }
             }
         });


### PR DESCRIPTION
### Problem

If the sink is broken, the Socket hearbeat thread will stay alive.

### Solution

Kill the heartbeat if the sink is broken.

### Bonus

Clean up the changelog.
