### PR TITLE
Clean up close tracing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - return `Err(Option<CloseFrame>)` from `ServerExt::on_connect()` to reject connections
 - robustness: `Server`, `Client`, `Session`, `Sink` interfaces now return `Result<(), tokio::sync::mpsc::error::SendError>` instead of potentially panicking
 - add reason to `ServerExt::on_disconnect()`
+- improved tracing emitted during close sequences
 
 
 Migration guide:


### PR DESCRIPTION
### Problem

During a normal close sequence, the socket of the client/server that initiated the close sequence would emit an error.

### Solution

Don't emit an error when you can't forward a close frame to the socket owner, because [according to the websocket spec](https://www.rfc-editor.org/rfc/rfc6455.html#section-1.4) it is normal for the recipient of a close frame to echo it back to the sender (who may have already shut down). Resolves #65.

I also snuck in a little optimization to client closing (no need to clone messages).