### PR TITLE
Cleanup leftover panics, downgrade errors to warnings where appropriate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - add reason to `ServerExt::on_disconnect()`
 - improved tracing emitted during close sequences
 - add `ClientConfig::query_parameter()` so connection requests can pass data via the URI (since additional connection headers are not supported by the websockets spec, this method should be more compatible with other implementations)
+- removed panics from the internals
+- downgraded tracing errors to warnings
 
 
 Migration guide:

--- a/src/client.rs
+++ b/src/client.rs
@@ -300,6 +300,7 @@ pub async fn connect<E: ClientExt + 'static>(
         let (stream, _) = tokio_tungstenite::connect_async(http_request).await?;
         if let Err(err) = client.on_connect().await {
             tracing::error!("calling on_connect() failed due to {}", err);
+            return Err(err);
         }
         let socket = Socket::new(stream, Config::default());
         tracing::info!("connected to {}", config.url);
@@ -314,7 +315,7 @@ pub async fn connect<E: ClientExt + 'static>(
         actor.run().await?;
         Ok(())
     });
-    let future = async move { future.await.unwrap() };
+    let future = async move { future.await.unwrap_or(Err("client actor crashed".into())) };
     (handle, future)
 }
 
@@ -354,20 +355,20 @@ impl<E: ClientExt> ClientActor<E> {
                                     tracing::trace!("client closed by server");
                                     match self.client.on_close(frame).await?
                                     {
-                                        ClientCloseMode::Reconnect => self.reconnect().await,
+                                        ClientCloseMode::Reconnect => { if !self.try_reconnect().await { return Ok(()) } }
                                         ClientCloseMode::Close => return Ok(())
                                     }
                                 }
                             };
                         }
                         Some(Err(error)) => {
-                            tracing::error!("connection error: {error}");
+                            tracing::warn!("connection error: {error}");
                         }
                         None => {
                             tracing::trace!("client socket died");
                             match self.client.on_disconnect().await?
                             {
-                                ClientCloseMode::Reconnect => self.reconnect().await,
+                                ClientCloseMode::Reconnect => { if !self.try_reconnect().await { return Ok(()) } }
                                 ClientCloseMode::Close => return Ok(())
                             }
                         }
@@ -380,11 +381,11 @@ impl<E: ClientExt> ClientActor<E> {
         Ok(())
     }
 
-    async fn reconnect(&mut self) {
-        let reconnect_interval = self
-            .config
-            .reconnect_interval
-            .expect("reconnect interval should be set for reconnecting");
+    async fn try_reconnect(&mut self) -> bool {
+        let Some(reconnect_interval) = self.config.reconnect_interval else {
+            tracing::warn!("no reconnect interval set, aborting reconnect attempt");
+            return false;
+        };
         tracing::info!("reconnecting in {}s", reconnect_interval.as_secs());
         for i in 1.. {
             tokio::time::sleep(reconnect_interval).await;
@@ -400,10 +401,10 @@ impl<E: ClientExt> ClientActor<E> {
                     let socket = Socket::new(socket, Config::default());
                     self.socket = socket;
                     self.heartbeat = Instant::now();
-                    return;
+                    return true;
                 }
                 Err(err) => {
-                    tracing::error!(
+                    tracing::warn!(
                         "reconnecting failed due to {}. will retry in {}s",
                         err,
                         reconnect_interval.as_secs()
@@ -411,5 +412,7 @@ impl<E: ClientExt> ClientActor<E> {
                 }
             };
         }
+
+        false
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -172,7 +172,7 @@ where
                 Ok::<_, Error>(())
             }
                 .await {
-                tracing::error!("error when processing: {err:?}");
+                tracing::warn!("error when processing: {err:?}");
             }
         }
     }

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -264,7 +264,7 @@ where
                             let timestamp = Duration::from_millis(timestamp as u64); // TODO: handle overflow
                             let latency = SystemTime::now()
                                 .duration_since(UNIX_EPOCH + timestamp)
-                                .unwrap();
+                                .unwrap_or(Duration::default());
                             // TODO: handle time zone
                             tracing::trace!("latency: {}ms", latency.as_millis());
                         }
@@ -358,7 +358,7 @@ impl Socket {
                     }
                     let timestamp = SystemTime::now()
                         .duration_since(std::time::UNIX_EPOCH)
-                        .unwrap();
+                        .unwrap_or(Duration::default());
                     let timestamp = timestamp.as_millis();
                     let bytes = timestamp.to_be_bytes();
                     if sink
@@ -373,7 +373,7 @@ impl Socket {
         });
 
         tokio::spawn(async move {
-            stream_future.await.unwrap();
+            stream_future.await.unwrap_or_default();
             sink_future.abort();
             heartbeat_future.abort();
         });


### PR DESCRIPTION
### Problem

- There are still panics in the internal implementation.
- Tracing errors are misused. An error indicates that something is broken and needs to be fixed. However, all of the current tracing errors merely indicate when something unexpected happened. Clients and servers should not treat problems caused by their counterparty as errors.

### Solution

- Remove all remaining panics.
- Downgrade tracing errors to warnings.
