### PR TITLE
Prevent tokio::select! from panicking

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -167,6 +167,7 @@ where
                     Some(call) = self.server_call_receiver.recv() => {
                         self.extension.on_call(call).await?
                     }
+                    else => return Err("server actor branches broken".into()),
                 }
                 Ok::<_, Error>(())
             }


### PR DESCRIPTION
### Problem

`tokio::select!` can panic if there is no `else` branch.

### Solution

Add missing `else` branch to the server actor.
