### PR TITLE
Allow clients to add query parameters to connection requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - robustness: `Server`, `Client`, `Session`, `Sink` interfaces now return `Result<(), tokio::sync::mpsc::error::SendError>` instead of potentially panicking
 - add reason to `ServerExt::on_disconnect()`
 - improved tracing emitted during close sequences
+- add `ClientConfig::query_parameter()` so connection requests can pass data via the URI (since additional connection headers are not supported by the websockets spec, this method should be more compatible with other implementations)
 
 
 Migration guide:

--- a/src/client.rs
+++ b/src/client.rs
@@ -92,6 +92,9 @@ impl ClientConfig {
         }
     }
 
+    /// Add 'basic' header.
+    /// Note that additional headers are not supported by the websockets spec, so may not be supported by all
+    /// implementations.
     pub fn basic(mut self, username: impl fmt::Display, password: impl fmt::Display) -> Self {
         let credentials =
             base64::engine::general_purpose::STANDARD.encode(format!("{username}:{password}"));
@@ -102,7 +105,10 @@ impl ClientConfig {
         self
     }
 
+    /// Add 'bearer' header.
     /// If invalid(outside of visible ASCII characters ranged between 32-127) token is passed, this function will panic.
+    /// Note that additional headers are not supported by the websockets spec, so may not be supported by all
+    /// implementations.
     pub fn bearer(mut self, token: impl fmt::Display) -> Self {
         self.headers.insert(
             http::header::AUTHORIZATION,
@@ -112,7 +118,11 @@ impl ClientConfig {
         self
     }
 
-    /// If you suppose the header name or value might be invalid, create `http::header::HeaderName` and `http::header::HeaderValue` on your side, and then pass it to this function
+    /// Add custom header.
+    /// If you suppose the header name or value might be invalid, create `http::header::HeaderName` and
+    /// `http::header::HeaderValue` on your side, and then pass it to this function.
+    /// Note that additional headers are not supported by the websockets spec, so may not be supported by all
+    /// implementations.
     pub fn header<K, V>(mut self, key: K, value: V) -> Self
     where
         HeaderName: TryFrom<K>,
@@ -129,6 +139,13 @@ impl ClientConfig {
             .map_err(Into::into)
             .expect("invalid header value");
         self.headers.insert(name, value);
+        self
+    }
+
+    /// Insert query parameters into the connection request URI.
+    /// Query parameters are supported by the websockets spec, so they will always be available to the connecting server.
+    pub fn query_parameter(mut self, key: &str, value: &str) -> Self {
+        self.url.query_pairs_mut().append_pair(key, value);
         self
     }
 


### PR DESCRIPTION
### Problem

See issue #74.

### Solution

Allow clients to insert query parameters to the connection request URI. This allows data passing that is in-spec.
