### PR TITLE
Allow injection of Ping message construction in socket heartbeat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Return `Ok(MessageSignal)` from `Client` and `Session` `.binary()/.text()/.close()` endpoints instead of `Ok(())`. The `MessageSignal::state()` method will indicate the current state of the message (sending/sent/failed).
 - Clients attempt to reconnect immediately instead of after one full reconnect interval.
 - Incoming user messages are discarded while a client is reconnecting, to better match the usual behavior of a websocket connection. If you want messages to be buffered while reconnecting, you should implement your own buffer.
+- rename `socket::Config` -> `socket::SocketConfig` and add a `heartbeat_ping_msg_fn` member variable in order to support custom Ping/Pong protocols
+    - add `ClientConfig::socket_config()` setter so clients can define their socket's config
 
 
 Migration guide:

--- a/src/axum.rs
+++ b/src/axum.rs
@@ -58,6 +58,7 @@
 //! }
 //! ```
 
+use crate::socket::SocketConfig;
 use crate::CloseCode;
 use crate::CloseFrame;
 use crate::RawMessage;
@@ -171,7 +172,8 @@ impl Upgrade {
     /// example.
     pub fn on_upgrade<E: ServerExt + 'static>(self, server: Server<E>) -> Response {
         self.ws.on_upgrade(move |socket| async move {
-            let socket = Socket::new(socket, Default::default()); // TODO: Make it really configurable via Extensions
+            // TODO: Make it really configurable via Extensions
+            let socket = Socket::new(socket, SocketConfig::default());
             server.accept(socket, self.request, self.address);
         })
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -185,8 +185,9 @@ pub trait ServerExt: Send {
     type Call: Send;
 
     /// Called when client connects to the server.
+    ///
     /// Here you should create a `Session` with your own implementation of `SessionExt` and return it.
-    ///If you don't want to accept the connection, return an error.
+    /// If you don't want to accept the connection, return an error.
     async fn on_connect(
         &mut self,
         socket: Socket,
@@ -203,6 +204,7 @@ pub trait ServerExt: Send {
         reason: Result<Option<CloseFrame>, Error>,
     ) -> Result<(), Error>;
     /// Handler for custom calls from other parts from your program.
+    ///
     /// This is useful for concurrency and polymorphism.
     async fn on_call(&mut self, call: Self::Call) -> Result<(), Error>;
 }

--- a/src/tungstenite.rs
+++ b/src/tungstenite.rs
@@ -31,7 +31,7 @@
 //! }
 //! ```
 
-use crate::socket::RawMessage;
+use crate::socket::{RawMessage, SocketConfig};
 use crate::tungstenite::tungstenite::handshake::server::ErrorResponse;
 use crate::CloseCode;
 use crate::CloseFrame;
@@ -139,7 +139,6 @@ cfg_if::cfg_if! {
         use crate::Server;
         use crate::Error;
         use crate::Socket;
-        use crate::socket;
         use crate::ServerExt;
 
         use tokio::net::TcpListener;
@@ -173,19 +172,19 @@ cfg_if::cfg_if! {
                 let socket = match self {
                     Acceptor::Plain => {
                         let socket = tokio_tungstenite::accept_hdr_async(stream, callback).await?;
-                        Socket::new(socket, socket::Config::default())
+                        Socket::new(socket, SocketConfig::default())
                     }
                     #[cfg(feature = "native-tls")]
                     Acceptor::NativeTls(acceptor) => {
                         let tls_stream = acceptor.accept(stream).await?;
                         let socket = tokio_tungstenite::accept_hdr_async(tls_stream, callback).await?;
-                        Socket::new(socket, socket::Config::default())
+                        Socket::new(socket, SocketConfig::default())
                     }
                     #[cfg(feature = "rustls")]
                     Acceptor::Rustls(acceptor) => {
                         let tls_stream = acceptor.accept(stream).await?;
                         let socket = tokio_tungstenite::accept_hdr_async(tls_stream, callback).await?;
-                        Socket::new(socket, socket::Config::default())
+                        Socket::new(socket, SocketConfig::default())
                     }
                 };
                 let Some(req_body) = req0 else { return Err("invalid request body".into()); };


### PR DESCRIPTION
### Problem

See issue #76.

### Solution

- Set the socket's `last_alive` every time a message is received, instead of only for `Pong`s. It's unfortunate we need a mutex here...
- Rename `socket::Config` -> `socket::SocketConfig` and add a `heartbeat_ping_msg_fn` member variable in order to support custom Ping/Pong protocols.
- Add `ClientConfig::socket_config()` setter so clients can define their socket's config.
- I also deleted the `heartbeat` member from `ClientExt` since it was unused and inaccessible.

### Future work

- Update the axum and tungstenite server implementations to allow dynamically defining the socket config for each new connection.