### PR TITLE
Refactor reconnect loop for use during initial connection attempt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Return `Ok(MessageSignal)` from `Client` and `Session` `.binary()/.text()/.close()` endpoints instead of `Ok(())`. The `MessageSignal::state()` method will indicate the current state of the message (sending/sent/failed).
 - Clients attempt to reconnect immediately instead of after one full reconnect interval.
 - Incoming user messages are discarded while a client is reconnecting, to better match the usual behavior of a websocket connection. If you want messages to be buffered while reconnecting, you should implement your own buffer.
-- rename `socket::Config` -> `socket::SocketConfig` and add a `heartbeat_ping_msg_fn` member variable in order to support custom Ping/Pong protocols
-    - add `ClientConfig::socket_config()` setter so clients can define their socket's config
-    - add `ezsockets::axum::Upgrade::on_upgrade_with_config()` that accepts a `SocketConfig`
+- Rename `socket::Config` -> `socket::SocketConfig` and add a `heartbeat_ping_msg_fn` member variable in order to support custom Ping/Pong protocols.
+    - Add `ClientConfig::socket_config()` setter so clients can define their socket's config.
+    - Add `ezsockets::axum::Upgrade::on_upgrade_with_config()` that accepts a `SocketConfig`.
+- Refactor `ezeockets::client::connect()` to use a retry loop for the initial connection. Add `max_initial_connect_attempts` and `max_reconnect_attempts` options to the `ClientConfig` (they default to 'infinite').
 
 
 Migration guide:


### PR DESCRIPTION
### Problem

When a client is created, it tries to connect one time. If that attempt fails, the client will die. See issue #15.

### Solution

- Refactor reconnect loop for use during the initial connection attempt.
- Add options to `ClientConfig` for the max number of initial connect attempts and max number of reconnect attempts.

### Future work

- Add `on_connect_fail()` to `ClientExt` for deciding what to do if an attempt fails.
