### PR TITLE
Emit sink shut down reason

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -94,7 +94,8 @@ impl<I: std::fmt::Display + Clone, C> Session<I, C> {
     #[doc(hidden)]
     /// WARN: Use only if really nessesary.
     ///
-    /// this uses some hack, which takes ownership of underlying `oneshot::Receiver`, making it inaccessible for all future calls of this method.
+    /// This uses some hack, which takes ownership of underlying `oneshot::Receiver`, making it inaccessible
+    /// for all future calls of this method.
     pub(super) async fn await_close(&self) -> Result<Option<CloseFrame>, Error> {
         let mut closed_indicator = self.closed_indicator.lock().await;
         let closed_indicator = closed_indicator


### PR DESCRIPTION
### Problem

Sending a message to the socket may fail if the sink has shut down. Currently, this always causes clients to immediately close instead of trying to reconnect. We want the client to always have a chance to reconnect when disconnected or closed by the server.

### Solution

Emit the socket sink error and update the client actor to ignore connection-related sink closure reasons. The server does not have a reconnect pattern, so we allow it to close a session if the session's socket sink shuts down.

