### PR TITLE
Add on_connect_fail() to ClientExt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add `ClientConnectorWasm` and `wasm_client` feature. Added `chat-client-wasm` example to show a WASM client that compiles. It currently only listens to the chat and can't input anything since browser does not have a terminal.
 - Refactor `Socket` and `Client` to not depend on `tokio` when compiling to WASM. This is a breaking change as the `Client` API now exposes `async_channel` error types instead of `tokio` error types, and `Client::call_with()` now takes an `async_channel::Sender` instead of a `tokio` oneshot.
 - Add unimplemented socket close codes.
+- Add `ClientExt::on_connect_fail()` for custom handling of connection attempt failures. By default the client will continue trying to connect.
 
 
 Migration guide:

--- a/src/client_connectors/client_connector_tokio.rs
+++ b/src/client_connectors/client_connector_tokio.rs
@@ -40,7 +40,6 @@ impl ClientConnector for ClientConnectorTokio {
     type Socket = tokio_tungstenite::WebSocketStream<
         tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
     >;
-    type ConnectError = tungstenite::error::Error;
 
     /// Get the connector's runtime handle.
     fn handle(&self) -> Self::Handle {
@@ -50,7 +49,7 @@ impl ClientConnector for ClientConnectorTokio {
     /// Connect to a websocket server.
     ///
     /// Returns `Err` if the request is invalid.
-    async fn connect(&self, config: &ClientConfig) -> Result<Self::Socket, Self::ConnectError> {
+    async fn connect(&self, config: &ClientConfig) -> Result<Self::Socket, Self::WSError> {
         let request = config.connect_http_request();
         let (socket, _) = tokio_tungstenite::connect_async(request).await?;
         Ok(socket)

--- a/src/client_connectors/client_connector_wasm.rs
+++ b/src/client_connectors/client_connector_wasm.rs
@@ -84,7 +84,6 @@ impl ClientConnector for ClientConnectorWasm {
     type Message = tokio_tungstenite_wasm::Message;
     type WSError = tokio_tungstenite_wasm::Error;
     type Socket = WebSocketStreamProxy;
-    type ConnectError = tokio_tungstenite_wasm::Error;
 
     /// Get the connector's runtime handle.
     fn handle(&self) -> Self::Handle {
@@ -97,7 +96,7 @@ impl ClientConnector for ClientConnectorWasm {
     ///
     /// Panics if any headers were added to the client config. Websockets on browser does not support
     /// additional headers (use [`ClientConfig::query_parameter()`] instead).
-    async fn connect(&self, config: &ClientConfig) -> Result<Self::Socket, Self::ConnectError> {
+    async fn connect(&self, config: &ClientConfig) -> Result<Self::Socket, Self::WSError> {
         if config.headers().len() > 0 {
             panic!("client may not submit HTTP headers in WASM connection requests");
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,5 +52,7 @@ cfg_if::cfg_if! {
     }
 }
 
+pub use tokio_tungstenite_wasm::Error as WSError;
+
 pub type Error = Box<dyn std::error::Error + Send + Sync>;
 pub type Request = http::Request<()>;


### PR DESCRIPTION
### Problem

The client connection loop executes continuously until either the client connects or the max connection attempts are exhausted. However, it may be useful to abort mid-way, for example if an auth token you are using for connection attempts has expired.

### Solution

Add `ClientExt::on_connect_fail()` for custom handling of connection attempt failures.
