### PR TITLE
Improve reconnect cleanup guarantees

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -610,7 +610,7 @@ async fn client_connect<E: ClientExt, Connector: ClientConnector>(
                         tracing::warn!("client is connecting, discarding message from user");
                         continue;
                     }
-                }
+                },
                 Err(async_channel::TryRecvError::Empty) => break,
                 Err(async_channel::TryRecvError::Closed) => {
                     tracing::warn!("client is dead, aborting connection attempts");


### PR DESCRIPTION
## Problem

A message sent via the `ClientExt` before or during a disconnect can hang in the client actor's `to_socket_receiver` buffer until the client is reconnected. This makes it difficult to synchronize message status tracking across a reconnect.

Specifically, I am implementing a request/response pattern in [bevy_simplenet](https://github.com/UkoeHB/bevy_simplenet), and I want to mark all un-resolved requests sent before a disconnect as `ResponseLost`. However, requests submitted before `ClientExt::on_disconnect()` is called can be buffered in `to_socket_receiver` and then sent to the new socket created after a reconnect. This means it is necessary to manually establish a sync point after the reconnect, which creates a ton of headaches.

## Solution

- Update client connection loop to always drain incoming messages before making a connection attempt.

This change means the user can be confident that messages with `MessageStatus::Sending` in `on_disconnect()` are guaranteed to fail.
