### PR TITLE
Update MessageSignal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## v0.6.2
+
+- Add `MessageSignal::new()`.
+
+
 ## v0.6.1
 
 - Tighten cleanup guarantees for outgoing client messages in reconnect cycles.


### PR DESCRIPTION
Add MessageSignal::new() so failed signals can be produced on demand, which is useful if you know a message will/should fail before submitting it.