### PR TITLE
Improve clarity of disconnect handling by removing implicit behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## v0.6.4
 
 - Guarantee the internal `SessionActor` is dropped before `ServerExt::on_disconnect` is called.
-- Force-close clients if they encounter an IO error, since an IO error might mean the client is hanging (e.g. after an IP address change) and should be reconstructed.
 - Return `CloseCode::Abnormal` from keepalive timeouts instead of `CloseCode::Normal`.
 - Fix DDOS by honest clients when servers check capacity *after* clients connect.
 


### PR DESCRIPTION
Reverts https://github.com/gbaranski/ezsockets/pull/110 and cleans up the code a little for clarity. It turns out `await_sink_close` can only return after the stream is shut down, so there is no case where the stream will hang.