### PR TITLE
Update to axum v0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## WIP
+
+- Update to `axum` v0.8.
+
+
 ## v0.6.4
 
 - Guarantee the internal `SessionActor` is dropped before `ServerExt::on_disconnect` is called.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,24 +21,24 @@ base64 = "0.21.0"
 enfync = "0.1.0"
 futures = "0.3.21"
 futures-util = { version = "0.3.25", default-features = false }
-http = "0.2.8"
+http = "1.2.0"
 tracing = "0.1.31"
-tungstenite = "0.20.0"
+tungstenite = "0.24.0"  # Locked to tokio-tungstenite-wasm version.
 url = "2.2.2"
 cfg-if = "1.0.0"
 
-axum = { version = "0.6.1", optional = true }
-axum-core = { version = "0.3.0", optional = true }
+axum = { version = "0.8.1", optional = true }
+axum-core = { version = "0.5.0", optional = true }
 bytes = { version = "1.3.0", optional = true }
 fragile = { version = "2.0", optional = true }
-http-body = { version = "0.4.5", optional = true }
+http-body = { version = "1.0.1", optional = true }
 hyper = { version = "0.14.23", optional = true }
 sha-1 = { version = "0.10.1", optional = true }
-tokio-tungstenite = { version = "0.20.0", optional = true }
+tokio-tungstenite = { version = "0.24.0", optional = true }
 
-tokio-tungstenite-wasm = { version = "0.2.1", optional = true }
+tokio-tungstenite-wasm = { version = "0.4.0", optional = true }
 
-tokio-rustls = { version = "0.24.1", optional = true }
+tokio-rustls = { version = "0.26.1", optional = true }
 tokio-native-tls = { version = "0.3.1", optional = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
@@ -99,3 +99,4 @@ required-features = ["tungstenite"]
 [[bench]]
 name = "my_benchmark"
 harness = false
+required-features = ["server", "tungstenite"]

--- a/examples/chat-server-axum/Cargo.toml
+++ b/examples/chat-server-axum/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 async-trait = "0.1.52"
-axum = "0.6.1"
+axum = "0.8.1"
 ezsockets = { path = "../../", features = ["axum"] }
 tokio = { version = "1.17.0", features = ["full"] }
 tracing = "0.1.32"

--- a/examples/chat-server-axum/src/main.rs
+++ b/examples/chat-server-axum/src/main.rs
@@ -11,6 +11,7 @@ use ezsockets::Server;
 use std::collections::HashMap;
 use std::io::BufRead;
 use std::net::SocketAddr;
+use tokio::net::TcpListener;
 
 type SessionID = u16;
 type Session = ezsockets::Session<SessionID, ()>;
@@ -123,10 +124,13 @@ async fn main() {
 
     tokio::spawn(async move {
         tracing::debug!("listening on {}", address);
-        axum::Server::bind(&address)
-            .serve(app.into_make_service_with_connect_info::<SocketAddr>())
-            .await
-            .unwrap();
+        let listener = TcpListener::bind("127.0.0.1:3000").await.unwrap();
+        axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<SocketAddr>(),
+        )
+        .await
+        .unwrap();
     });
 
     let stdin = std::io::stdin();

--- a/src/server_runners/axum_tungstenite.rs
+++ b/src/server_runners/axum_tungstenite.rs
@@ -10,7 +10,6 @@
 #![cfg_attr(test, allow(clippy::float_cmp))]
 
 use self::rejection::*;
-use async_trait::async_trait;
 use axum_core::{
     extract::FromRequestParts,
     response::{IntoResponse, Response},
@@ -238,7 +237,6 @@ impl<C> WebSocketUpgrade<C> {
     }
 }
 
-#[async_trait]
 impl<S> FromRequestParts<S> for WebSocketUpgrade
 where
     S: Sync,


### PR DESCRIPTION
Updates axum to v0.8. Could not update tungstenite all the way to v0.26 because `tokio-tungstenite-wasm` is not fully up to date.