### PR TITLE
fix: retry on SendAfterClosing and bump tokio-tungstenite-wasm to 0.6.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ hyper-util = { version = "0.1.10", optional = true }  # Locked to axum version.
 sha-1 = { version = "0.10.1", optional = true }
 tokio-tungstenite = { version = "0.26.1", optional = true }
 
-tokio-tungstenite-wasm = { version = "0.5.0", optional = true }
+tokio-tungstenite-wasm = { version = "0.6.1", optional = true }
 
 tokio-rustls = { version = "0.26.1", optional = true }
 tokio-native-tls = { version = "0.3.1", optional = true }


### PR DESCRIPTION
Before this PR, the ezsockets client would crash (with no retries) when it encountered a `ProtocolError::SendAfterClosing` during execution of the `handle_outgoing_msg` function. Since this method already retries on `WSError::AlreadyClosed`, it’s reasonable that it should also retry on `ProtocolError::SendAfterClosing`. However, matching on `ProtocolError` required a [patch](https://github.com/TannerRogalsky/tokio-tungstenite-wasm/pull/18) to `tokio-tungstenite-wasm`, which explains the version bump for that crate.